### PR TITLE
feat: introduced `LoadBalancer` for service

### DIFF
--- a/internal/adapter/service.go
+++ b/internal/adapter/service.go
@@ -62,6 +62,14 @@ func (adapter *KubeDockerAdapter) CreateContainerFromService(ctx context.Context
 		return nil
 	}
 
+	// ExternalName services are not supported
+	if service.Spec.Type == corev1.ServiceTypeExternalName {
+		logger.Infow("externalName service detected. The service will be ignored",
+			"service_name", service.Name,
+		)
+		return nil
+	}
+
 	containers, err := adapter.cli.ContainerList(ctx, types.ContainerListOptions{})
 	if err != nil {
 		return fmt.Errorf("unable to list containers: %w", err)


### PR DESCRIPTION
This PR is to introduce the `LoadBalancer` service type to close https://github.com/portainer/k2d/issues/15.

**Implementation**

For the deployment, if the service type is detected as the `LoadBalancer`, it follows the same process as `NodePort`, where it loops through the list of ports defined in the `.spec.ports`, but the difference is the `hostBinding.HostPort` becomes the service port, so the low-end port is published at the host level.

<details>
<summary>Example YAML</summary>

```yaml
apiVersion: v1
kind: Service
metadata:
  name: my-nginx-svc
  labels:
    app: nginx
spec:
  type: LoadBalancer
  ports:
  - protocol: TCP
    port: 80
    targetport: 80
  selector:
    app: nginx
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: my-nginx
  labels:
    app: nginx
spec:
  replicas: 1
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
      - name: nginx
        image: nginx:1.14.2
        ports:
        - containerPort: 80
```

</details>

For the `GET` part, it sets the `external-ip` to match the server IP address where `k2d` runs. An example run below:

<details>
<summary>Example Run</summary>

```sh
(⎈|k2d:N/A)➜  k2d-lb (feat/lb) k get svc                                                                                                                                                                        [1:47:00]  ✭
NAME           TYPE           CLUSTER-IP      EXTERNAL-IP      PORT(S)    AGE
my-nginx-svc   LoadBalancer   192.168.148.2   192.168.68.250   8080/TCP   75s
(⎈|k2d:N/A)➜  k2d-lb (feat/lb) curl 192.168.68.250:8080                                                                                                                                                         [1:48:18]  ✭
<!DOCTYPE html>
<html>
<head>
<title>Welcome to nginx!</title>
```

</details>

Also, as part of this PR, I have added an exclusion of the `ExternalName` service type we do not support yet.