### PR TITLE
feat: add support for private registries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/portainer/k2d
 go 1.20
 
 require (
+	github.com/docker/distribution v2.8.2+incompatible
 	github.com/docker/docker v24.0.2+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/emicklei/go-restful-openapi/v2 v2.9.1
@@ -25,7 +26,6 @@ require (
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/docker/distribution v2.8.2+incompatible // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect

--- a/internal/adapter/adapter.go
+++ b/internal/adapter/adapter.go
@@ -7,6 +7,7 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/portainer/k2d/internal/adapter/converter"
 	"github.com/portainer/k2d/internal/adapter/filesystem"
+	"github.com/portainer/k2d/internal/adapter/memory"
 	"github.com/portainer/k2d/internal/types"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -26,7 +27,9 @@ type (
 	KubeDockerAdapter struct {
 		cli                    *client.Client
 		converter              *converter.DockerAPIConverter
-		fileSystemStore        *filesystem.FileSystemStore
+		configMapStore         types.ConfigMapStore
+		secretStore            types.SecretStore
+		registrySecretStore    types.SecretStore
 		logger                 *zap.SugaredLogger
 		conversionScheme       *runtime.Scheme
 		startTime              time.Time
@@ -73,7 +76,9 @@ func NewKubeDockerAdapter(options *KubeDockerAdapterOptions) (*KubeDockerAdapter
 	return &KubeDockerAdapter{
 		cli:                    cli,
 		converter:              converter.NewDockerAPIConverter(filesystemStore, options.ServerConfiguration),
-		fileSystemStore:        filesystemStore,
+		configMapStore:         filesystemStore,
+		secretStore:            filesystemStore,
+		registrySecretStore:    memory.NewInMemoryStore(),
 		logger:                 options.Logger,
 		conversionScheme:       scheme,
 		startTime:              time.Now(),

--- a/internal/adapter/configmap.go
+++ b/internal/adapter/configmap.go
@@ -10,15 +10,15 @@ import (
 )
 
 func (adapter *KubeDockerAdapter) CreateConfigMap(configMap *corev1.ConfigMap) error {
-	return adapter.fileSystemStore.StoreConfigMap(configMap)
+	return adapter.configMapStore.StoreConfigMap(configMap)
 }
 
 func (adapter *KubeDockerAdapter) DeleteConfigMap(configMapName string) error {
-	return adapter.fileSystemStore.DeleteConfigMap(configMapName)
+	return adapter.configMapStore.DeleteConfigMap(configMapName)
 }
 
 func (adapter *KubeDockerAdapter) GetConfigMap(configMapName string) (*corev1.ConfigMap, error) {
-	configMap, err := adapter.fileSystemStore.GetConfigMap(configMapName)
+	configMap, err := adapter.configMapStore.GetConfigMap(configMapName)
 	if err != nil {
 		return &corev1.ConfigMap{}, fmt.Errorf("unable to get configmap: %w", err)
 	}
@@ -71,5 +71,5 @@ func (adapter *KubeDockerAdapter) ListConfigMaps() (corev1.ConfigMapList, error)
 }
 
 func (adapter *KubeDockerAdapter) listConfigMaps() (core.ConfigMapList, error) {
-	return adapter.fileSystemStore.GetConfigMaps()
+	return adapter.configMapStore.GetConfigMaps()
 }

--- a/internal/adapter/memory/store.go
+++ b/internal/adapter/memory/store.go
@@ -1,0 +1,99 @@
+package memory
+
+import (
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/kubernetes/pkg/apis/core"
+)
+
+type SecretData struct {
+	// Data map[string][]byte `json:"data"`
+	Data map[string][]byte
+}
+
+type (
+	InMemoryStore struct {
+		m         sync.RWMutex
+		secretMap map[string]SecretData
+	}
+)
+
+func NewInMemoryStore() *InMemoryStore {
+	return &InMemoryStore{
+		m:         sync.RWMutex{},
+		secretMap: make(map[string]SecretData),
+	}
+}
+
+func (s *InMemoryStore) DeleteSecret(secretName string) error {
+	s.m.Lock()
+	defer s.m.Unlock()
+	delete(s.secretMap, secretName)
+	return nil
+}
+
+func (s *InMemoryStore) GetSecret(secretName string) (*core.Secret, error) {
+	s.m.RLock()
+	defer s.m.RUnlock()
+	data, found := s.secretMap[secretName]
+	if !found {
+		return nil, nil
+	}
+
+	return &core.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        secretName,
+			Annotations: map[string]string{},
+			Namespace:   "default",
+		},
+		Data: data.Data,
+		// Type: core.SecretTypeOpaque,
+	}, nil
+}
+
+func (s *InMemoryStore) GetSecrets(selector labels.Selector) (core.SecretList, error) {
+	s.m.RLock()
+	defer s.m.RUnlock()
+	var secrets []core.Secret
+
+	for name, data := range s.secretMap {
+
+		secret := core.Secret{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Secret",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        name,
+				Annotations: map[string]string{},
+				Namespace:   "default",
+			},
+			Data: data.Data,
+			// Type: core.SecretTypeOpaque,
+		}
+
+		secrets = append(secrets, secret)
+	}
+
+	return core.SecretList{
+		Items: secrets,
+	}, nil
+}
+
+func (s *InMemoryStore) StoreSecret(secret *corev1.Secret) error {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	s.secretMap[secret.Name] = SecretData{
+		Data: secret.Data,
+	}
+
+	return nil
+}

--- a/internal/adapter/secret.go
+++ b/internal/adapter/secret.go
@@ -80,19 +80,6 @@ func (adapter *KubeDockerAdapter) GetSecretTable(selector labels.Selector) (*met
 }
 
 func (adapter *KubeDockerAdapter) getSecret(secretName string) (*core.Secret, error) {
-	// secret, err := adapter.secretStore.GetSecret(secretName)
-	// if err != nil {
-	// 	if !errors.Is(err, filesystem.ErrSecretNotFound) {
-	// 		return nil, fmt.Errorf("unable to get secret: %w", err)
-	// 	}
-
-	// 	// If not found in secretStore, try to fetch from registrySecretStore
-	// 	secret, err = adapter.registrySecretStore.GetSecret(secretName)
-	// 	if err != nil {
-	// 		return nil, fmt.Errorf("unable to get registry secret: %w", err)
-	// 	}
-	// }
-
 	secret, err := adapter.secretStore.GetSecret(secretName)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get secret: %w", err)

--- a/internal/api/core/v1/secrets/get.go
+++ b/internal/api/core/v1/secrets/get.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 
 	"github.com/emicklei/go-restful/v3"
-	"github.com/portainer/k2d/internal/adapter/filesystem"
+	"github.com/portainer/k2d/internal/adapter"
 	"github.com/portainer/k2d/internal/api/utils"
 )
 
@@ -14,7 +14,7 @@ func (svc SecretService) GetSecret(r *restful.Request, w *restful.Response) {
 	secretName := r.PathParameter("name")
 
 	secret, err := svc.adapter.GetSecret(secretName)
-	if err != nil && errors.Is(err, filesystem.ErrSecretNotFound) {
+	if err != nil && errors.Is(err, adapter.ErrSecretNotFound) {
 		w.WriteHeader(http.StatusNotFound)
 		return
 	} else if err != nil {

--- a/internal/api/core/v1/secrets/patch.go
+++ b/internal/api/core/v1/secrets/patch.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 
 	"github.com/emicklei/go-restful/v3"
-	"github.com/portainer/k2d/internal/adapter/filesystem"
+	"github.com/portainer/k2d/internal/adapter"
 	"github.com/portainer/k2d/internal/api/utils"
 	"github.com/portainer/k2d/internal/controller"
 	"github.com/portainer/k2d/internal/types"
@@ -27,7 +27,7 @@ func (svc SecretService) PatchSecret(r *restful.Request, w *restful.Response) {
 	}
 
 	secret, err := svc.adapter.GetSecret(secretName)
-	if err != nil && errors.Is(err, filesystem.ErrSecretNotFound) {
+	if err != nil && errors.Is(err, adapter.ErrSecretNotFound) {
 		w.WriteHeader(http.StatusNotFound)
 		return
 	} else if err != nil {

--- a/internal/api/core/v1/secrets/put.go
+++ b/internal/api/core/v1/secrets/put.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/emicklei/go-restful/v3"
-	"github.com/portainer/k2d/internal/adapter/filesystem"
+	"github.com/portainer/k2d/internal/adapter"
 	"github.com/portainer/k2d/internal/api/utils"
 	httputils "github.com/portainer/k2d/pkg/http"
 	corev1 "k8s.io/api/core/v1"
@@ -49,7 +49,7 @@ func (svc SecretService) PutSecret(r *restful.Request, w *restful.Response) {
 			return
 		}
 
-		if err != nil && !errors.Is(err, filesystem.ErrSecretNotFound) {
+		if err != nil && !errors.Is(err, adapter.ErrSecretNotFound) {
 			utils.HttpError(r, w, http.StatusInternalServerError, fmt.Errorf("unable to get secret: %w", err))
 			return
 		}

--- a/internal/k8s/secret_registry.go
+++ b/internal/k8s/secret_registry.go
@@ -1,0 +1,70 @@
+package k8s
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"k8s.io/kubernetes/pkg/apis/core"
+)
+
+// dockerConfig represents a part of the docker config json file
+type dockerConfig struct {
+	Auths map[string]struct {
+		Auth string `json:"auth"`
+	} `json:"auths"`
+}
+
+// GetRegistryAuthFromSecret extracts the username and password for a given registry URL from a Kubernetes Secret.
+// The secret is expected to contain a field named ".dockerconfigjson" with the encoded Docker registry configuration.
+// The function iterates through the "Auths" section of the Docker config to find the matching registry URL and
+// decodes the base64-encoded authentication string to return the username and password.
+//
+// Parameters:
+// secret - Pointer to the Kubernetes Secret object containing the Docker registry configuration.
+// registryURL - The URL of the registry for which the credentials are needed.
+//
+// Returns:
+//   - string: The username associated with the registry.
+//   - string: The password associated with the registry.
+//   - error: An error if the Docker config is not found, if there is a failure in decoding the JSON,
+//     if the registry is not found in the Docker config, if the auth string cannot be decoded,
+//     or if the auth string is in an invalid format.
+func GetRegistryAuthFromSecret(secret *core.Secret, registryURL string) (string, string, error) {
+	if _, ok := secret.Data[".dockerconfigjson"]; !ok {
+		return "", "", fmt.Errorf("docker config json not found in secret")
+	}
+
+	dockerConfigJSON := secret.Data[".dockerconfigjson"]
+
+	var dockerConfig dockerConfig
+	if err := json.Unmarshal(dockerConfigJSON, &dockerConfig); err != nil {
+		return "", "", fmt.Errorf("unable to decode registry docker config: %w", err)
+	}
+
+	registryKey := ""
+	for registry := range dockerConfig.Auths {
+		if strings.Contains(registry, registryURL) {
+			registryKey = registry
+		}
+	}
+
+	if registryKey == "" {
+		return "", "", fmt.Errorf("registry %s not found in docker config", registryURL)
+	}
+
+	auth := dockerConfig.Auths[registryKey].Auth
+	decodedString, err := base64.StdEncoding.DecodeString(auth)
+	if err != nil {
+		return "", "", fmt.Errorf("unable to decode auth string: %w", err)
+	}
+
+	decodedAuth := string(decodedString)
+	authData := strings.Split(decodedAuth, ":")
+	if len(authData) != 2 {
+		return "", "", fmt.Errorf("invalid auth string: %s", decodedAuth)
+	}
+
+	return authData[0], authData[1], nil
+}

--- a/internal/types/configmap.go
+++ b/internal/types/configmap.go
@@ -1,0 +1,14 @@
+package types
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/kubernetes/pkg/apis/core"
+)
+
+// ConfigMapStore is an interface for interacting with Kubernetes ConfigMaps.
+type ConfigMapStore interface {
+	DeleteConfigMap(configMapName string) error
+	GetConfigMap(configMapName string) (*core.ConfigMap, error)
+	GetConfigMaps() (core.ConfigMapList, error)
+	StoreConfigMap(configMap *corev1.ConfigMap) error
+}

--- a/internal/types/secret.go
+++ b/internal/types/secret.go
@@ -1,0 +1,15 @@
+package types
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/kubernetes/pkg/apis/core"
+)
+
+// SecretStore is an interface for interacting with Kubernetes Secrets.
+type SecretStore interface {
+	DeleteSecret(secretName string) error
+	GetSecret(secretName string) (*core.Secret, error)
+	GetSecrets(selector labels.Selector) (core.SecretList, error)
+	StoreSecret(secret *corev1.Secret) error
+}


### PR DESCRIPTION
This implementation adds support for deploying workloads from private registries via the use of ImagePullSecrets.

The current implementation only reads the first secret in the ImagePullSecret list.

Closes #17 