### PR TITLE
feat: introduce namespace support

### DIFF
--- a/internal/adapter/container_utils.go
+++ b/internal/adapter/container_utils.go
@@ -253,11 +253,11 @@ func (adapter *KubeDockerAdapter) createContainerFromPodSpec(ctx context.Context
 
 // DeleteContainer removes a Docker container given its ID or name.
 // This function will force the removal of the container, regardless if it's running or not.
-// It will return an error if the Docker client fails to remove the container for any reason.
+// It will log a warning if it fails to delete the container.
 func (adapter *KubeDockerAdapter) DeleteContainer(ctx context.Context, containerID string) error {
 	err := adapter.cli.ContainerRemove(ctx, containerID, types.ContainerRemoveOptions{Force: true})
 	if err != nil {
-		return fmt.Errorf("unable to remove container: %w", err)
+		adapter.logger.Warnf("unable to remove container: %s", err)
 	}
 
 	return nil

--- a/internal/adapter/converter/namespace.go
+++ b/internal/adapter/converter/namespace.go
@@ -1,0 +1,35 @@
+package converter
+
+import (
+	"time"
+
+	"github.com/docker/docker/api/types"
+	k2dtypes "github.com/portainer/k2d/internal/adapter/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/apis/core"
+)
+
+func (converter *DockerAPIConverter) ConvertNetworkToNamespace(network *types.NetworkResource) *core.Namespace {
+	if network.Name == "k2d_net" {
+		network.Name = "default"
+	}
+
+	namespace := &core.Namespace{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Namespace",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              network.Name,
+			CreationTimestamp: metav1.NewTime(time.Unix(network.Created.Unix(), 0)),
+			Annotations: map[string]string{
+				"kubectl.kubernetes.io/last-applied-configuration": network.Labels[k2dtypes.NamespaceLastAppliedConfigLabelKey],
+			},
+		},
+		Status: core.NamespaceStatus{
+			Phase: core.NamespaceActive,
+		},
+	}
+
+	return namespace
+}

--- a/internal/adapter/converter/namespace.go
+++ b/internal/adapter/converter/namespace.go
@@ -10,10 +10,6 @@ import (
 )
 
 func (converter *DockerAPIConverter) ConvertNetworkToNamespace(network *types.NetworkResource) *core.Namespace {
-	if network.Name == "k2d_net" {
-		network.Name = "default"
-	}
-
 	namespace := &core.Namespace{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Namespace",

--- a/internal/adapter/converter/pod.go
+++ b/internal/adapter/converter/pod.go
@@ -29,7 +29,7 @@ func (converter *DockerAPIConverter) ConvertContainerToPod(container types.Conta
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              containerName,
 			CreationTimestamp: metav1.NewTime(time.Unix(container.Created, 0)),
-			Namespace:         "default",
+			Namespace:         container.Labels[k2dtypes.NamespaceLabelKey],
 			Annotations: map[string]string{
 				"kubectl.kubernetes.io/last-applied-configuration": container.Labels[k2dtypes.WorkloadLastAppliedConfigLabelKey],
 			},
@@ -74,7 +74,7 @@ func (converter *DockerAPIConverter) ConvertContainerToPod(container types.Conta
 // ConvertPodSpecToContainerConfiguration converts a Kubernetes PodSpec into a Docker container configuration.
 // It receives a Kubernetes PodSpec and a map of labels.
 // It returns a ContainerConfiguration struct, or an error if the conversion fails.
-func (converter *DockerAPIConverter) ConvertPodSpecToContainerConfiguration(spec core.PodSpec, labels map[string]string) (ContainerConfiguration, error) {
+func (converter *DockerAPIConverter) ConvertPodSpecToContainerConfiguration(spec core.PodSpec, networkName string, labels map[string]string) (ContainerConfiguration, error) {
 	containerSpec := spec.Containers[0]
 
 	containerConfig := &container.Config{
@@ -118,7 +118,7 @@ func (converter *DockerAPIConverter) ConvertPodSpecToContainerConfiguration(spec
 		HostConfig:      hostConfig,
 		NetworkConfig: &network.NetworkingConfig{
 			EndpointsConfig: map[string]*network.EndpointSettings{
-				k2dtypes.K2DNetworkName: {},
+				networkName: {},
 			},
 		},
 	}, nil

--- a/internal/adapter/converter/pod.go
+++ b/internal/adapter/converter/pod.go
@@ -113,6 +113,11 @@ func (converter *DockerAPIConverter) ConvertPodSpecToContainerConfiguration(spec
 		return ContainerConfiguration{}, err
 	}
 
+	// ensure the default namespaces points to the default k2d_net network
+	if networkName == "default" {
+		networkName = "k2d_net"
+	}
+
 	return ContainerConfiguration{
 		ContainerConfig: containerConfig,
 		HostConfig:      hostConfig,

--- a/internal/adapter/converter/service.go
+++ b/internal/adapter/converter/service.go
@@ -73,7 +73,7 @@ func (converter *DockerAPIConverter) UpdateServiceFromContainerInfo(service *cor
 		service.Spec.Type = core.ServiceTypeClusterIP
 	}
 
-	service.Spec.ClusterIPs = []string{container.NetworkSettings.Networks[k2dtypes.K2DNetworkName].IPAddress}
+	service.Spec.ClusterIPs = []string{container.NetworkSettings.Networks[service.Namespace].IPAddress}
 
 	if service.Spec.Type != core.ServiceTypeClusterIP {
 		servicePorts := []core.ServicePort{}

--- a/internal/adapter/converter/service.go
+++ b/internal/adapter/converter/service.go
@@ -73,7 +73,12 @@ func (converter *DockerAPIConverter) UpdateServiceFromContainerInfo(service *cor
 		service.Spec.Type = core.ServiceTypeClusterIP
 	}
 
-	service.Spec.ClusterIPs = []string{container.NetworkSettings.Networks[service.Namespace].IPAddress}
+	network := service.Namespace
+	if network == "default" {
+		network = "k2d_net"
+	}
+
+	service.Spec.ClusterIPs = []string{container.NetworkSettings.Networks[network].IPAddress}
 
 	if service.Spec.Type != core.ServiceTypeClusterIP {
 		servicePorts := []core.ServicePort{}

--- a/internal/adapter/namespace.go
+++ b/internal/adapter/namespace.go
@@ -1,16 +1,30 @@
 package adapter
 
 import (
+	"context"
 	"fmt"
 
+	k2dtypes "github.com/portainer/k2d/internal/adapter/types"
 	"github.com/portainer/k2d/internal/k8s"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/apis/core"
 )
 
-func (adapter *KubeDockerAdapter) ListNamespaces() (corev1.NamespaceList, error) {
-	namespaceList := adapter.listNamespaces()
+func (adapter *KubeDockerAdapter) CreateNetworkFromNamespace(ctx context.Context, namespace *corev1.Namespace) error {
+	err := adapter.CreateNetworkFromNamespaceSpec(ctx, *namespace)
+	if err != nil {
+		return fmt.Errorf("unable to create network from namespace spec: %w", err)
+	}
+
+	return nil
+}
+
+func (adapter *KubeDockerAdapter) ListNamespaces(ctx context.Context) (corev1.NamespaceList, error) {
+	namespaceList, err := adapter.listNamespaces(ctx)
+	if err != nil {
+		return corev1.NamespaceList{}, fmt.Errorf("unable to list namespaces: %w", err)
+	}
 
 	versionedNamespaceList := corev1.NamespaceList{
 		TypeMeta: metav1.TypeMeta{
@@ -19,7 +33,7 @@ func (adapter *KubeDockerAdapter) ListNamespaces() (corev1.NamespaceList, error)
 		},
 	}
 
-	err := adapter.ConvertK8SResource(&namespaceList, &versionedNamespaceList)
+	err = adapter.ConvertK8SResource(&namespaceList, &versionedNamespaceList)
 	if err != nil {
 		return corev1.NamespaceList{}, fmt.Errorf("unable to convert internal NamespaceList to versioned NamespaceList: %w", err)
 	}
@@ -27,51 +41,70 @@ func (adapter *KubeDockerAdapter) ListNamespaces() (corev1.NamespaceList, error)
 	return versionedNamespaceList, nil
 }
 
-func (adapter *KubeDockerAdapter) GetNamespace() (*corev1.Namespace, error) {
-	return &corev1.Namespace{
+func (adapter *KubeDockerAdapter) GetNamespace(ctx context.Context, namespaceName string) (*corev1.Namespace, error) {
+	network, err := adapter.GetNetwork(ctx, namespaceName)
+	if err != nil {
+		return &corev1.Namespace{}, fmt.Errorf("unable to get the namespaces: %w", err)
+	}
+
+	if network == nil {
+		return nil, nil
+	}
+
+	versionedNamespace := corev1.Namespace{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Namespace",
 			APIVersion: "v1",
 		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "default",
-			CreationTimestamp: metav1.Time{
-				Time: adapter.startTime,
-			},
-		},
-		Status: corev1.NamespaceStatus{
-			Phase: corev1.NamespaceActive,
-		},
-	}, nil
+	}
+
+	namespace := adapter.converter.ConvertNetworkToNamespace(network)
+
+	err = adapter.ConvertK8SResource(namespace, &versionedNamespace)
+	if err != nil {
+		return nil, fmt.Errorf("unable to convert internal object to versioned object: %w", err)
+	}
+
+	return &versionedNamespace, nil
 }
 
-func (adapter *KubeDockerAdapter) GetNamespaceTable() (*metav1.Table, error) {
-	namespaceList := adapter.listNamespaces()
+func (adapter *KubeDockerAdapter) GetNamespaceTable(ctx context.Context) (*metav1.Table, error) {
+	namespaceList, err := adapter.listNamespaces(ctx)
+	if err != nil {
+		return &metav1.Table{}, fmt.Errorf("unable to list namespaces: %w", err)
+	}
 	return k8s.GenerateTable(&namespaceList)
 }
 
-func (adapter *KubeDockerAdapter) listNamespaces() core.NamespaceList {
+func (adapter *KubeDockerAdapter) listNamespaces(ctx context.Context) (core.NamespaceList, error) {
+	networks, err := adapter.ListNetworks(ctx)
+	if err != nil {
+		adapter.logger.Errorf("unable to list networks: %v", err)
+		return core.NamespaceList{}, err
+	}
+
+	namespaceList := []core.Namespace{}
+
+	for _, network := range networks {
+		if network.Labels[k2dtypes.NamespaceLabelKey] != "" {
+			namespaceList = append(namespaceList, *adapter.converter.ConvertNetworkToNamespace(&network))
+		}
+	}
 	return core.NamespaceList{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "NamespaceList",
 			APIVersion: "v1",
 		},
-		Items: []core.Namespace{
-			{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "Namespace",
-					APIVersion: "v1",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "default",
-					CreationTimestamp: metav1.Time{
-						Time: adapter.startTime,
-					},
-				},
-				Status: core.NamespaceStatus{
-					Phase: core.NamespaceActive,
-				},
-			},
-		},
+
+		Items: namespaceList,
+	}, nil
+}
+
+func (adapter *KubeDockerAdapter) DeleteNamespace(ctx context.Context, namespaceName string) error {
+	err := adapter.DeleteNetwork(ctx, namespaceName)
+	if err != nil {
+		return fmt.Errorf("unable to delete the namespaces: %w", err)
 	}
+
+	return nil
 }

--- a/internal/adapter/network_utils.go
+++ b/internal/adapter/network_utils.go
@@ -2,25 +2,14 @@ package adapter
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
 	k2dtypes "github.com/portainer/k2d/internal/adapter/types"
+	corev1 "k8s.io/api/core/v1"
 )
-
-// findMatchingNetwork searches through the provided slice of NetworkResource types,
-// looking for a network resource that matches the provided networkName.
-// If a matching network resource is found, it returns a pointer to it.
-// If no match is found, it returns nil.
-func findMatchingNetwork(networks []types.NetworkResource, networkName string) *types.NetworkResource {
-	for _, network := range networks {
-		if network.Name == networkName {
-			return &network
-		}
-	}
-
-	return nil
-}
 
 // EnsureRequiredDockerResourcesExist verifies the existence of required Docker resources
 // for k2d to work. If the required resources do not exist, it will attempt to create them.
@@ -30,21 +19,101 @@ func findMatchingNetwork(networks []types.NetworkResource, networkName string) *
 //
 // It returns an error if it fails to list Docker networks or if it fails to create the required Docker network.
 func (adapter *KubeDockerAdapter) EnsureRequiredDockerResourcesExist(ctx context.Context) error {
-	networks, err := adapter.cli.NetworkList(ctx, types.NetworkListOptions{})
+	k2dNetwork, err := adapter.GetNetwork(ctx, k2dtypes.K2DNetworkName)
 	if err != nil {
-		return fmt.Errorf("unable to list docker networks: %w", err)
+		return fmt.Errorf("unable to list networks: %w", err)
 	}
 
-	k2dNetwork := findMatchingNetwork(networks, k2dtypes.K2DNetworkName)
 	if k2dNetwork == nil {
 		adapter.logger.Info("creating k2d container network")
-		_, err := adapter.cli.NetworkCreate(ctx, k2dtypes.K2DNetworkName, types.NetworkCreate{})
+		_, err := adapter.cli.NetworkCreate(ctx, k2dtypes.K2DNetworkName, types.NetworkCreate{
+			Labels: map[string]string{
+				k2dtypes.NamespaceLabelKey: "default",
+			},
+		})
 		if err != nil {
 			return fmt.Errorf("unable to create k2d container network: %w", err)
 		}
 
 	} else {
 		adapter.logger.Info("k2d container network already exists, skipping creation")
+	}
+
+	return nil
+}
+
+// GetNetwork searches through the provided slice of NetworkResource types,
+// looking for a network resource that matches the provided networkName.
+// If a matching network resource is found, it returns a pointer to it.
+// If no match is found, it returns nil.
+func (adapter *KubeDockerAdapter) GetNetwork(ctx context.Context, networkName string) (*types.NetworkResource, error) {
+	if networkName == "default" {
+		networkName = "k2d_net"
+	}
+
+	labelFilter := filters.NewArgs()
+	labelFilter.Add("name", networkName)
+	network, err := adapter.cli.NetworkList(ctx, types.NetworkListOptions{Filters: labelFilter})
+	if err != nil {
+		return &types.NetworkResource{}, fmt.Errorf("unable to list networks: %w", err)
+	}
+
+	if len(network) == 0 {
+		return nil, nil
+	}
+
+	return &network[0], nil
+}
+
+// ListNetwork returns a list of Docker networks.
+// It returns an error if it fails to list the networks.
+func (adapter *KubeDockerAdapter) ListNetworks(ctx context.Context) ([]types.NetworkResource, error) {
+	networks, err := adapter.cli.NetworkList(ctx, types.NetworkListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("unable to list networks: %w", err)
+	}
+
+	return networks, nil
+}
+
+// CreateNetworkFromNamespace creates a Docker network with the provided name.
+// It returns an error if it fails to create the network.
+func (adapter *KubeDockerAdapter) CreateNetworkFromNamespaceSpec(ctx context.Context, namespace corev1.Namespace) error {
+	adapter.logger.Infof("creating network %s", namespace.Name)
+	if namespace.Labels["app.kubernetes.io/managed-by"] == "Helm" {
+		namespaceData, err := json.Marshal(namespace)
+		if err != nil {
+			return fmt.Errorf("unable to marshal deployment: %w", err)
+		}
+		namespace.ObjectMeta.Annotations["kubectl.kubernetes.io/last-applied-configuration"] = string(namespaceData)
+	}
+
+	lastAppliedConfiguration := ""
+	if namespace.ObjectMeta.Annotations["kubectl.kubernetes.io/last-applied-configuration"] != "" {
+		lastAppliedConfiguration = namespace.ObjectMeta.Annotations["kubectl.kubernetes.io/last-applied-configuration"]
+	}
+
+	_, err := adapter.cli.NetworkCreate(ctx, namespace.Name, types.NetworkCreate{
+		Driver: "bridge",
+		Labels: map[string]string{
+			k2dtypes.NamespaceLabelKey:                  namespace.Name,
+			k2dtypes.NamespaceLastAppliedConfigLabelKey: lastAppliedConfiguration,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("unable to create network %s: %w", namespace.Name, err)
+	}
+
+	return nil
+}
+
+// DeleteNetwork deletes a Docker network with the provided name.
+// It returns an error if it fails to delete the network.
+func (adapter *KubeDockerAdapter) DeleteNetwork(ctx context.Context, networkName string) error {
+	adapter.logger.Infof("deleting network %s", networkName)
+	err := adapter.cli.NetworkRemove(ctx, networkName)
+	if err != nil {
+		return fmt.Errorf("unable to delete network %s: %w", networkName, err)
 	}
 
 	return nil

--- a/internal/adapter/network_utils.go
+++ b/internal/adapter/network_utils.go
@@ -2,13 +2,11 @@ package adapter
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	k2dtypes "github.com/portainer/k2d/internal/adapter/types"
-	corev1 "k8s.io/api/core/v1"
 )
 
 // EnsureRequiredDockerResourcesExist verifies the existence of required Docker resources
@@ -19,12 +17,14 @@ import (
 //
 // It returns an error if it fails to list Docker networks or if it fails to create the required Docker network.
 func (adapter *KubeDockerAdapter) EnsureRequiredDockerResourcesExist(ctx context.Context) error {
-	k2dNetwork, err := adapter.GetNetwork(ctx, k2dtypes.K2DNetworkName)
+	k2dNetwork, err := adapter.GetNetwork(ctx, "default")
 	if err != nil {
 		return fmt.Errorf("unable to list networks: %w", err)
 	}
 
-	if k2dNetwork == nil {
+	if k2dNetwork != nil {
+		adapter.logger.Info("k2d container network already exists, skipping creation")
+	} else {
 		adapter.logger.Info("creating k2d container network")
 		_, err := adapter.cli.NetworkCreate(ctx, k2dtypes.K2DNetworkName, types.NetworkCreate{
 			Labels: map[string]string{
@@ -34,9 +34,6 @@ func (adapter *KubeDockerAdapter) EnsureRequiredDockerResourcesExist(ctx context
 		if err != nil {
 			return fmt.Errorf("unable to create k2d container network: %w", err)
 		}
-
-	} else {
-		adapter.logger.Info("k2d container network already exists, skipping creation")
 	}
 
 	return nil
@@ -47,12 +44,13 @@ func (adapter *KubeDockerAdapter) EnsureRequiredDockerResourcesExist(ctx context
 // If a matching network resource is found, it returns a pointer to it.
 // If no match is found, it returns nil.
 func (adapter *KubeDockerAdapter) GetNetwork(ctx context.Context, networkName string) (*types.NetworkResource, error) {
+	labelFilter := filters.NewArgs()
+	labelFilter.Add("label", fmt.Sprintf("%s=%s", k2dtypes.NamespaceLabelKey, networkName))
+
 	if networkName == "default" {
-		networkName = "k2d_net"
+		labelFilter.Add("name", "k2d_net")
 	}
 
-	labelFilter := filters.NewArgs()
-	labelFilter.Add("name", networkName)
 	network, err := adapter.cli.NetworkList(ctx, types.NetworkListOptions{Filters: labelFilter})
 	if err != nil {
 		return &types.NetworkResource{}, fmt.Errorf("unable to list networks: %w", err)
@@ -63,58 +61,4 @@ func (adapter *KubeDockerAdapter) GetNetwork(ctx context.Context, networkName st
 	}
 
 	return &network[0], nil
-}
-
-// ListNetwork returns a list of Docker networks.
-// It returns an error if it fails to list the networks.
-func (adapter *KubeDockerAdapter) ListNetworks(ctx context.Context) ([]types.NetworkResource, error) {
-	networks, err := adapter.cli.NetworkList(ctx, types.NetworkListOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("unable to list networks: %w", err)
-	}
-
-	return networks, nil
-}
-
-// CreateNetworkFromNamespace creates a Docker network with the provided name.
-// It returns an error if it fails to create the network.
-func (adapter *KubeDockerAdapter) CreateNetworkFromNamespaceSpec(ctx context.Context, namespace corev1.Namespace) error {
-	adapter.logger.Infof("creating network %s", namespace.Name)
-	if namespace.Labels["app.kubernetes.io/managed-by"] == "Helm" {
-		namespaceData, err := json.Marshal(namespace)
-		if err != nil {
-			return fmt.Errorf("unable to marshal deployment: %w", err)
-		}
-		namespace.ObjectMeta.Annotations["kubectl.kubernetes.io/last-applied-configuration"] = string(namespaceData)
-	}
-
-	lastAppliedConfiguration := ""
-	if namespace.ObjectMeta.Annotations["kubectl.kubernetes.io/last-applied-configuration"] != "" {
-		lastAppliedConfiguration = namespace.ObjectMeta.Annotations["kubectl.kubernetes.io/last-applied-configuration"]
-	}
-
-	_, err := adapter.cli.NetworkCreate(ctx, namespace.Name, types.NetworkCreate{
-		Driver: "bridge",
-		Labels: map[string]string{
-			k2dtypes.NamespaceLabelKey:                  namespace.Name,
-			k2dtypes.NamespaceLastAppliedConfigLabelKey: lastAppliedConfiguration,
-		},
-	})
-	if err != nil {
-		return fmt.Errorf("unable to create network %s: %w", namespace.Name, err)
-	}
-
-	return nil
-}
-
-// DeleteNetwork deletes a Docker network with the provided name.
-// It returns an error if it fails to delete the network.
-func (adapter *KubeDockerAdapter) DeleteNetwork(ctx context.Context, networkName string) error {
-	adapter.logger.Infof("deleting network %s", networkName)
-	err := adapter.cli.NetworkRemove(ctx, networkName)
-	if err != nil {
-		return fmt.Errorf("unable to delete network %s: %w", networkName, err)
-	}
-
-	return nil
 }

--- a/internal/adapter/pod.go
+++ b/internal/adapter/pod.go
@@ -7,6 +7,7 @@ import (
 	"io"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
 	k2dtypes "github.com/portainer/k2d/internal/adapter/types"
 	"github.com/portainer/k2d/internal/k8s"
 	corev1 "k8s.io/api/core/v1"
@@ -23,6 +24,7 @@ type PodLogOptions struct {
 func (adapter *KubeDockerAdapter) CreateContainerFromPod(ctx context.Context, pod *corev1.Pod) error {
 	opts := ContainerCreationOptions{
 		containerName: pod.Name,
+		networkName:   pod.Namespace,
 		podSpec:       pod.Spec,
 		labels:        pod.Labels,
 	}
@@ -40,8 +42,11 @@ func (adapter *KubeDockerAdapter) CreateContainerFromPod(ctx context.Context, po
 	return adapter.createContainerFromPodSpec(ctx, opts)
 }
 
-func (adapter *KubeDockerAdapter) GetPod(ctx context.Context, podName string) (*corev1.Pod, error) {
-	containers, err := adapter.cli.ContainerList(ctx, types.ContainerListOptions{All: true})
+func (adapter *KubeDockerAdapter) GetPod(ctx context.Context, podName string, namespaceName string) (*corev1.Pod, error) {
+	labelFilter := filters.NewArgs()
+	labelFilter.Add("label", fmt.Sprintf("%s=%s", k2dtypes.NamespaceLabelKey, namespaceName))
+
+	containers, err := adapter.cli.ContainerList(ctx, types.ContainerListOptions{All: true, Filters: labelFilter})
 	if err != nil {
 		return nil, fmt.Errorf("unable to list containers: %w", err)
 	}
@@ -72,13 +77,19 @@ func (adapter *KubeDockerAdapter) GetPod(ctx context.Context, podName string) (*
 	return nil, nil
 }
 
-func (adapter *KubeDockerAdapter) GetPodLogs(ctx context.Context, podName string, opts PodLogOptions) (io.ReadCloser, error) {
-	containers, err := adapter.cli.ContainerList(ctx, types.ContainerListOptions{All: true})
+func (adapter *KubeDockerAdapter) GetPodLogs(ctx context.Context, namespaceName string, podName string, opts PodLogOptions) (io.ReadCloser, error) {
+	labelFilter := filters.NewArgs()
+	labelFilter.Add("label", fmt.Sprintf("%s=%s", k2dtypes.NamespaceLabelKey, namespaceName))
+
+	adapter.logger.Debug("Listing containers", "labelFilter", labelFilter)
+
+	containers, err := adapter.cli.ContainerList(ctx, types.ContainerListOptions{All: true, Filters: labelFilter})
 	if err != nil {
 		return nil, fmt.Errorf("unable to list containers: %w", err)
 	}
 
 	for _, container := range containers {
+		adapter.logger.Debug("Found container", "container", container)
 		if container.Names[0] == "/"+podName {
 			return adapter.cli.ContainerLogs(ctx, container.ID, types.ContainerLogsOptions{
 				ShowStdout: true,
@@ -93,8 +104,8 @@ func (adapter *KubeDockerAdapter) GetPodLogs(ctx context.Context, podName string
 	return nil, nil
 }
 
-func (adapter *KubeDockerAdapter) GetPodTable(ctx context.Context) (*metav1.Table, error) {
-	podList, err := adapter.listPods(ctx)
+func (adapter *KubeDockerAdapter) GetPodTable(ctx context.Context, namespaceName string) (*metav1.Table, error) {
+	podList, err := adapter.listPods(ctx, namespaceName)
 	if err != nil {
 		return &metav1.Table{}, fmt.Errorf("unable to list pods: %w", err)
 	}
@@ -102,8 +113,8 @@ func (adapter *KubeDockerAdapter) GetPodTable(ctx context.Context) (*metav1.Tabl
 	return k8s.GenerateTable(&podList)
 }
 
-func (adapter *KubeDockerAdapter) ListPods(ctx context.Context) (corev1.PodList, error) {
-	podList, err := adapter.listPods(ctx)
+func (adapter *KubeDockerAdapter) ListPods(ctx context.Context, namespaceName string) (corev1.PodList, error) {
+	podList, err := adapter.listPods(ctx, namespaceName)
 	if err != nil {
 		return corev1.PodList{}, fmt.Errorf("unable to list pods: %w", err)
 	}
@@ -145,8 +156,11 @@ func (adapter *KubeDockerAdapter) getPod(container types.Container) (*core.Pod, 
 	return &pod, nil
 }
 
-func (adapter *KubeDockerAdapter) listPods(ctx context.Context) (core.PodList, error) {
-	containers, err := adapter.cli.ContainerList(ctx, types.ContainerListOptions{All: true})
+func (adapter *KubeDockerAdapter) listPods(ctx context.Context, namespaceName string) (core.PodList, error) {
+	labelFilter := filters.NewArgs()
+	labelFilter.Add("label", fmt.Sprintf("%s=%s", k2dtypes.NamespaceLabelKey, namespaceName))
+
+	containers, err := adapter.cli.ContainerList(ctx, types.ContainerListOptions{All: true, Filters: labelFilter})
 	if err != nil {
 		return core.PodList{}, fmt.Errorf("unable to list containers: %w", err)
 	}

--- a/internal/adapter/service.go
+++ b/internal/adapter/service.go
@@ -128,7 +128,12 @@ func (adapter *KubeDockerAdapter) CreateContainerFromService(ctx context.Context
 	}
 
 	// Update with namespace as well
-	cfg.NetworkConfig.EndpointsConfig[service.Namespace].Aliases = []string{
+	network := service.Namespace
+	if network == "default" {
+		network = "k2d_net"
+	}
+
+	cfg.NetworkConfig.EndpointsConfig[network].Aliases = []string{
 		service.Name,
 		fmt.Sprintf("%s.%s", service.Name, service.Namespace),
 		fmt.Sprintf("%s.%s.svc", service.Name, service.Namespace),

--- a/internal/adapter/types/namespace.go
+++ b/internal/adapter/types/namespace.go
@@ -1,0 +1,8 @@
+package types
+
+const (
+	// NamespaceLastAppliedConfigLabelKey is the key used to store the namespace specific last applied configuration in the container labels
+	NamespaceLastAppliedConfigLabelKey = "namespace.k2d.io/last-applied-configuration"
+	// NamespaceLabelKey is the key used to store the namespace name in the container labels
+	NamespaceLabelKey = "namespace.k2d.io/name"
+)

--- a/internal/api/apis/apps/deployments/create.go
+++ b/internal/api/apis/apps/deployments/create.go
@@ -13,12 +13,18 @@ import (
 )
 
 func (svc DeploymentService) CreateDeployment(r *restful.Request, w *restful.Response) {
+	namespace := r.PathParameter("namespace")
+
 	deployment := &appsv1.Deployment{}
 
 	err := httputils.ParseJSONBody(r.Request, &deployment)
 	if err != nil {
 		utils.HttpError(r, w, http.StatusBadRequest, fmt.Errorf("unable to parse request body: %w", err))
 		return
+	}
+
+	if namespace != "" {
+		deployment.Namespace = namespace
 	}
 
 	dryRun := r.QueryParameter("dryRun") != ""

--- a/internal/api/apis/apps/deployments/deployments.go
+++ b/internal/api/apis/apps/deployments/deployments.go
@@ -31,13 +31,15 @@ func (svc DeploymentService) RegisterDeploymentAPI(ws *restful.WebService) {
 
 	ws.Route(ws.POST("/v1/namespaces/{namespace}/deployments").
 		To(svc.CreateDeployment).
-		Param(ws.QueryParameter("dryRun", "when present, indicates that modifications should not be persisted").DataType("string")))
+		Param(ws.QueryParameter("dryRun", "when present, indicates that modifications should not be persisted").DataType("string")).
+		Param(ws.PathParameter("namespace", "namespace of the deployment").DataType("string")))
 
 	ws.Route(ws.GET("/v1/deployments").
 		To(svc.ListDeployments))
 
 	ws.Route(ws.GET("/v1/namespaces/{namespace}/deployments").
-		To(svc.ListDeployments))
+		To(svc.ListDeployments).
+		Param(ws.PathParameter("namespace", "namespace of the deployment").DataType("string")))
 
 	ws.Route(ws.DELETE("/v1/deployments/{name}").
 		To(svc.DeleteDeployment).
@@ -45,6 +47,7 @@ func (svc DeploymentService) RegisterDeploymentAPI(ws *restful.WebService) {
 
 	ws.Route(ws.DELETE("/v1/namespaces/{namespace}/deployments/{name}").
 		To(svc.DeleteDeployment).
+		Param(ws.PathParameter("namespace", "namespace of the deployment").DataType("string")).
 		Param(ws.PathParameter("name", "name of the deployment").DataType("string")))
 
 	ws.Route(ws.GET("/v1/deployments/{name}").
@@ -53,6 +56,7 @@ func (svc DeploymentService) RegisterDeploymentAPI(ws *restful.WebService) {
 
 	ws.Route(ws.GET("/v1/namespaces/{namespace}/deployments/{name}").
 		To(svc.GetDeployment).
+		Param(ws.PathParameter("namespace", "namespace of the deployment").DataType("string")).
 		Param(ws.PathParameter("name", "name of the deployment").DataType("string")))
 
 	ws.Route(ws.PATCH("/v1/deployments/{name}").
@@ -65,5 +69,6 @@ func (svc DeploymentService) RegisterDeploymentAPI(ws *restful.WebService) {
 		To(svc.PatchDeployment).
 		Param(ws.QueryParameter("dryRun", "when present, indicates that modifications should not be persisted").DataType("string")).
 		AddExtension("x-kubernetes-group-version-kind", deploymentGVKExtension).
+		Param(ws.PathParameter("namespace", "namespace of the deployment").DataType("string")).
 		Param(ws.PathParameter("name", "name of the deployment").DataType("string")))
 }

--- a/internal/api/apis/apps/deployments/get.go
+++ b/internal/api/apis/apps/deployments/get.go
@@ -10,8 +10,9 @@ import (
 
 func (svc DeploymentService) GetDeployment(r *restful.Request, w *restful.Response) {
 	deploymentName := r.PathParameter("name")
+	namespaceName := r.PathParameter("namespace")
 
-	deployment, err := svc.adapter.GetDeployment(r.Request.Context(), deploymentName)
+	deployment, err := svc.adapter.GetDeployment(r.Request.Context(), deploymentName, namespaceName)
 	if err != nil {
 		utils.HttpError(r, w, http.StatusInternalServerError, fmt.Errorf("unable to get deployment: %w", err))
 		return

--- a/internal/api/apis/apps/deployments/list.go
+++ b/internal/api/apis/apps/deployments/list.go
@@ -5,15 +5,19 @@ import (
 
 	"github.com/emicklei/go-restful/v3"
 	"github.com/portainer/k2d/internal/api/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func (svc DeploymentService) ListDeployments(r *restful.Request, w *restful.Response) {
+	namespaceName := r.PathParameter("namespace")
 	utils.ListResources(
 		r,
 		w,
 		func(ctx context.Context) (interface{}, error) {
-			return svc.adapter.ListDeployments(ctx)
+			return svc.adapter.ListDeployments(ctx, namespaceName)
 		},
-		svc.adapter.GetDeploymentTable,
+		func(ctx context.Context) (*metav1.Table, error) {
+			return svc.adapter.GetDeploymentTable(ctx, namespaceName)
+		},
 	)
 }

--- a/internal/api/apis/apps/deployments/patch.go
+++ b/internal/api/apis/apps/deployments/patch.go
@@ -16,6 +16,7 @@ import (
 
 func (svc DeploymentService) PatchDeployment(r *restful.Request, w *restful.Response) {
 	deploymentName := r.PathParameter("name")
+	namespaceName := r.PathParameter("namespace")
 
 	patch, err := io.ReadAll(r.Request.Body)
 	if err != nil {
@@ -23,7 +24,7 @@ func (svc DeploymentService) PatchDeployment(r *restful.Request, w *restful.Resp
 		return
 	}
 
-	deployment, err := svc.adapter.GetDeployment(r.Request.Context(), deploymentName)
+	deployment, err := svc.adapter.GetDeployment(r.Request.Context(), deploymentName, namespaceName)
 	if err != nil {
 		utils.HttpError(r, w, http.StatusInternalServerError, fmt.Errorf("unable to get deployment: %w", err))
 		return

--- a/internal/api/core/v1/namespaces/create.go
+++ b/internal/api/core/v1/namespaces/create.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/emicklei/go-restful/v3"
 	"github.com/portainer/k2d/internal/api/utils"
+	"github.com/portainer/k2d/internal/controller"
+	"github.com/portainer/k2d/internal/types"
 	httputils "github.com/portainer/k2d/pkg/http"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -18,6 +20,14 @@ func (svc NamespaceService) CreateNamespace(r *restful.Request, w *restful.Respo
 		utils.HttpError(r, w, http.StatusBadRequest, fmt.Errorf("unable to parse request body: %w", err))
 		return
 	}
+
+	dryRun := r.QueryParameter("dryRun") != ""
+	if dryRun {
+		w.WriteAsJson(namespace)
+		return
+	}
+
+	svc.operations <- controller.NewOperation(namespace, controller.HighPriorityOperation, r.HeaderParameter(types.RequestIDHeader))
 
 	w.WriteAsJson(namespace)
 }

--- a/internal/api/core/v1/namespaces/delete.go
+++ b/internal/api/core/v1/namespaces/delete.go
@@ -1,0 +1,35 @@
+package namespaces
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/emicklei/go-restful/v3"
+	"github.com/portainer/k2d/internal/api/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (svc NamespaceService) DeleteNamespace(r *restful.Request, w *restful.Response) {
+	namespaceName := r.PathParameter("name")
+
+	// prevent the default network deletion as k2d runs on it
+	if namespaceName == "default" {
+		utils.HttpError(r, w, http.StatusBadRequest, fmt.Errorf("unable to delete the default namespace as it is the main namespace k2d runs on"))
+		return
+	} else {
+		err := svc.adapter.DeleteNetwork(r.Request.Context(), namespaceName)
+		if err != nil {
+			utils.HttpError(r, w, http.StatusInternalServerError, fmt.Errorf("unable to delete network: %w", err))
+			return
+		}
+	}
+
+	w.WriteAsJson(metav1.Status{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Status",
+			APIVersion: "v1",
+		},
+		Status: "Success",
+		Code:   http.StatusOK,
+	})
+}

--- a/internal/api/core/v1/namespaces/delete.go
+++ b/internal/api/core/v1/namespaces/delete.go
@@ -12,16 +12,10 @@ import (
 func (svc NamespaceService) DeleteNamespace(r *restful.Request, w *restful.Response) {
 	namespaceName := r.PathParameter("name")
 
-	// prevent the default network deletion as k2d runs on it
-	if namespaceName == "default" {
-		utils.HttpError(r, w, http.StatusBadRequest, fmt.Errorf("unable to delete the default namespace as it is the main namespace k2d runs on"))
+	err := svc.adapter.DeleteNamespace(r.Request.Context(), namespaceName)
+	if err != nil {
+		utils.HttpError(r, w, http.StatusInternalServerError, fmt.Errorf("unable to delete network: %w", err))
 		return
-	} else {
-		err := svc.adapter.DeleteNetwork(r.Request.Context(), namespaceName)
-		if err != nil {
-			utils.HttpError(r, w, http.StatusInternalServerError, fmt.Errorf("unable to delete network: %w", err))
-			return
-		}
 	}
 
 	w.WriteAsJson(metav1.Status{

--- a/internal/api/core/v1/namespaces/get.go
+++ b/internal/api/core/v1/namespaces/get.go
@@ -10,8 +10,9 @@ import (
 
 func (svc NamespaceService) GetNamespace(r *restful.Request, w *restful.Response) {
 	name := r.PathParameter("name")
+	watch := r.PathParameter("watch")
 
-	namespace, err := svc.adapter.GetNamespace(r.Request.Context(), name)
+	namespace, err := svc.adapter.GetNamespace(r.Request.Context(), name, watch)
 	if err != nil {
 		utils.HttpError(r, w, http.StatusInternalServerError, fmt.Errorf("unable to get namespace: %w", err))
 		return

--- a/internal/api/core/v1/namespaces/get.go
+++ b/internal/api/core/v1/namespaces/get.go
@@ -9,7 +9,9 @@ import (
 )
 
 func (svc NamespaceService) GetNamespace(r *restful.Request, w *restful.Response) {
-	namespace, err := svc.adapter.GetNamespace()
+	name := r.PathParameter("name")
+
+	namespace, err := svc.adapter.GetNamespace(r.Request.Context(), name)
 	if err != nil {
 		utils.HttpError(r, w, http.StatusInternalServerError, fmt.Errorf("unable to get namespace: %w", err))
 		return

--- a/internal/api/core/v1/namespaces/list.go
+++ b/internal/api/core/v1/namespaces/list.go
@@ -13,10 +13,10 @@ func (svc NamespaceService) ListNamespaces(r *restful.Request, w *restful.Respon
 		r,
 		w,
 		func(ctx context.Context) (interface{}, error) {
-			return svc.adapter.ListNamespaces()
+			return svc.adapter.ListNamespaces(ctx)
 		},
 		func(ctx context.Context) (*metav1.Table, error) {
-			return svc.adapter.GetNamespaceTable()
+			return svc.adapter.GetNamespaceTable(ctx)
 		},
 	)
 }

--- a/internal/api/core/v1/namespaces/namespaces.go
+++ b/internal/api/core/v1/namespaces/namespaces.go
@@ -3,21 +3,31 @@ package namespaces
 import (
 	"github.com/emicklei/go-restful/v3"
 	"github.com/portainer/k2d/internal/adapter"
+	"github.com/portainer/k2d/internal/controller"
 )
 
 type NamespaceService struct {
-	adapter *adapter.KubeDockerAdapter
+	adapter    *adapter.KubeDockerAdapter
+	operations chan controller.Operation
 }
 
-func NewNamespaceService(adapter *adapter.KubeDockerAdapter) NamespaceService {
+func NewNamespaceService(adapter *adapter.KubeDockerAdapter, operations chan controller.Operation) NamespaceService {
 	return NamespaceService{
-		adapter: adapter,
+		adapter:    adapter,
+		operations: operations,
 	}
 }
 
 func (svc NamespaceService) RegisterNamespaceAPI(ws *restful.WebService) {
+	namespaceGVKExtension := map[string]string{
+		"group":   "",
+		"kind":    "Namespace",
+		"version": "v1",
+	}
+
 	ws.Route(ws.POST("/v1/namespaces").
-		To(svc.CreateNamespace))
+		To(svc.CreateNamespace).
+		Param(ws.QueryParameter("dryRun", "when present, indicates that modifications should not be persisted").DataType("string")))
 
 	ws.Route(ws.GET("/v1/namespaces").
 		To(svc.ListNamespaces))
@@ -25,4 +35,14 @@ func (svc NamespaceService) RegisterNamespaceAPI(ws *restful.WebService) {
 	ws.Route(ws.GET("/v1/namespaces/{name}").
 		To(svc.GetNamespace).
 		Param(ws.PathParameter("name", "name of the node").DataType("string")))
+
+	ws.Route(ws.PATCH("/v1/namespaces/{name}").
+		To(svc.PatchNamespace).
+		Param(ws.QueryParameter("dryRun", "when present, indicates that modifications should not be persisted").DataType("string")).
+		AddExtension("x-kubernetes-group-version-kind", namespaceGVKExtension).
+		Param(ws.PathParameter("name", "name of the namespace").DataType("string")))
+
+	ws.Route(ws.DELETE("/v1/namespaces/{name}").
+		To(svc.DeleteNamespace).
+		Param(ws.PathParameter("name", "name of the pod").DataType("string")))
 }

--- a/internal/api/core/v1/namespaces/namespaces.go
+++ b/internal/api/core/v1/namespaces/namespaces.go
@@ -34,7 +34,8 @@ func (svc NamespaceService) RegisterNamespaceAPI(ws *restful.WebService) {
 
 	ws.Route(ws.GET("/v1/namespaces/{name}").
 		To(svc.GetNamespace).
-		Param(ws.PathParameter("name", "name of the namespace").DataType("string")))
+		Param(ws.PathParameter("name", "name of the namespace").DataType("string")).
+		Param(ws.PathParameter("watch", "watch for changes").DataType("boolean")))
 
 	ws.Route(ws.PATCH("/v1/namespaces/{name}").
 		To(svc.PatchNamespace).

--- a/internal/api/core/v1/namespaces/namespaces.go
+++ b/internal/api/core/v1/namespaces/namespaces.go
@@ -34,7 +34,7 @@ func (svc NamespaceService) RegisterNamespaceAPI(ws *restful.WebService) {
 
 	ws.Route(ws.GET("/v1/namespaces/{name}").
 		To(svc.GetNamespace).
-		Param(ws.PathParameter("name", "name of the node").DataType("string")))
+		Param(ws.PathParameter("name", "name of the namespace").DataType("string")))
 
 	ws.Route(ws.PATCH("/v1/namespaces/{name}").
 		To(svc.PatchNamespace).
@@ -44,5 +44,5 @@ func (svc NamespaceService) RegisterNamespaceAPI(ws *restful.WebService) {
 
 	ws.Route(ws.DELETE("/v1/namespaces/{name}").
 		To(svc.DeleteNamespace).
-		Param(ws.PathParameter("name", "name of the pod").DataType("string")))
+		Param(ws.PathParameter("name", "name of the namespace").DataType("string")))
 }

--- a/internal/api/core/v1/namespaces/patch.go
+++ b/internal/api/core/v1/namespaces/patch.go
@@ -17,9 +17,6 @@ import (
 func (svc NamespaceService) PatchNamespace(r *restful.Request, w *restful.Response) {
 	namespaceName := r.PathParameter("name")
 
-	// print namespaceName
-	fmt.Println("namespaceName: ", namespaceName)
-
 	patch, err := io.ReadAll(r.Request.Body)
 	if err != nil {
 		utils.HttpError(r, w, http.StatusBadRequest, fmt.Errorf("unable to parse request body: %w", err))

--- a/internal/api/core/v1/namespaces/patch.go
+++ b/internal/api/core/v1/namespaces/patch.go
@@ -1,0 +1,69 @@
+package namespaces
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/emicklei/go-restful/v3"
+	"github.com/portainer/k2d/internal/adapter/filesystem"
+	"github.com/portainer/k2d/internal/api/utils"
+	"github.com/portainer/k2d/internal/controller"
+	"github.com/portainer/k2d/internal/types"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+)
+
+func (svc NamespaceService) PatchNamespace(r *restful.Request, w *restful.Response) {
+	namespaceName := r.PathParameter("name")
+
+	// print namespaceName
+	fmt.Println("namespaceName: ", namespaceName)
+
+	patch, err := io.ReadAll(r.Request.Body)
+	if err != nil {
+		utils.HttpError(r, w, http.StatusBadRequest, fmt.Errorf("unable to parse request body: %w", err))
+		return
+	}
+
+	namespace, err := svc.adapter.GetNamespace(r.Request.Context(), namespaceName)
+	if err != nil && errors.Is(err, filesystem.ErrSecretNotFound) {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	} else if err != nil {
+		utils.HttpError(r, w, http.StatusInternalServerError, fmt.Errorf("unable to get namespace: %w", err))
+		return
+	}
+
+	data, err := json.Marshal(namespace)
+	if err != nil {
+		utils.HttpError(r, w, http.StatusInternalServerError, fmt.Errorf("unable to marshal namespace: %w", err))
+		return
+	}
+
+	mergedData, err := strategicpatch.StrategicMergePatch(data, patch, corev1.Namespace{})
+	if err != nil {
+		utils.HttpError(r, w, http.StatusInternalServerError, fmt.Errorf("unable to apply patch: %w", err))
+		return
+	}
+
+	updatedNamespace := &corev1.Namespace{}
+
+	err = json.Unmarshal(mergedData, updatedNamespace)
+	if err != nil {
+		utils.HttpError(r, w, http.StatusInternalServerError, fmt.Errorf("unable to unmarshal namespace: %w", err))
+		return
+	}
+
+	dryRun := r.QueryParameter("dryRun") != ""
+	if dryRun {
+		w.WriteAsJson(updatedNamespace)
+		return
+	}
+
+	svc.operations <- controller.NewOperation(updatedNamespace, controller.HighPriorityOperation, r.HeaderParameter(types.RequestIDHeader))
+
+	w.WriteAsJson(updatedNamespace)
+}

--- a/internal/api/core/v1/namespaces/patch.go
+++ b/internal/api/core/v1/namespaces/patch.go
@@ -2,13 +2,11 @@ package namespaces
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
 
 	"github.com/emicklei/go-restful/v3"
-	"github.com/portainer/k2d/internal/adapter/filesystem"
 	"github.com/portainer/k2d/internal/api/utils"
 	"github.com/portainer/k2d/internal/controller"
 	"github.com/portainer/k2d/internal/types"
@@ -29,10 +27,7 @@ func (svc NamespaceService) PatchNamespace(r *restful.Request, w *restful.Respon
 	}
 
 	namespace, err := svc.adapter.GetNamespace(r.Request.Context(), namespaceName)
-	if err != nil && errors.Is(err, filesystem.ErrSecretNotFound) {
-		w.WriteHeader(http.StatusNotFound)
-		return
-	} else if err != nil {
+	if err != nil {
 		utils.HttpError(r, w, http.StatusInternalServerError, fmt.Errorf("unable to get namespace: %w", err))
 		return
 	}

--- a/internal/api/core/v1/namespaces/patch.go
+++ b/internal/api/core/v1/namespaces/patch.go
@@ -16,6 +16,7 @@ import (
 
 func (svc NamespaceService) PatchNamespace(r *restful.Request, w *restful.Response) {
 	namespaceName := r.PathParameter("name")
+	watch := r.PathParameter("watch")
 
 	patch, err := io.ReadAll(r.Request.Body)
 	if err != nil {
@@ -23,7 +24,7 @@ func (svc NamespaceService) PatchNamespace(r *restful.Request, w *restful.Respon
 		return
 	}
 
-	namespace, err := svc.adapter.GetNamespace(r.Request.Context(), namespaceName)
+	namespace, err := svc.adapter.GetNamespace(r.Request.Context(), namespaceName, watch)
 	if err != nil {
 		utils.HttpError(r, w, http.StatusInternalServerError, fmt.Errorf("unable to get namespace: %w", err))
 		return

--- a/internal/api/core/v1/pods/create.go
+++ b/internal/api/core/v1/pods/create.go
@@ -13,12 +13,18 @@ import (
 )
 
 func (svc PodService) CreatePod(r *restful.Request, w *restful.Response) {
+	namespace := r.PathParameter("namespace")
+
 	pod := &corev1.Pod{}
 
 	err := httputils.ParseJSONBody(r.Request, &pod)
 	if err != nil {
 		utils.HttpError(r, w, http.StatusBadRequest, fmt.Errorf("unable to parse request body: %w", err))
 		return
+	}
+
+	if namespace != "" {
+		pod.Namespace = namespace
 	}
 
 	dryRun := r.QueryParameter("dryRun") != ""

--- a/internal/api/core/v1/pods/get.go
+++ b/internal/api/core/v1/pods/get.go
@@ -10,8 +10,9 @@ import (
 
 func (svc PodService) GetPod(r *restful.Request, w *restful.Response) {
 	podName := r.PathParameter("name")
+	namespaceName := r.PathParameter("namespace")
 
-	pod, err := svc.adapter.GetPod(r.Request.Context(), podName)
+	pod, err := svc.adapter.GetPod(r.Request.Context(), podName, namespaceName)
 	if err != nil {
 		utils.HttpError(r, w, http.StatusInternalServerError, fmt.Errorf("unable to get pod: %w", err))
 		return

--- a/internal/api/core/v1/pods/list.go
+++ b/internal/api/core/v1/pods/list.go
@@ -5,15 +5,19 @@ import (
 
 	"github.com/emicklei/go-restful/v3"
 	"github.com/portainer/k2d/internal/api/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func (svc PodService) ListPods(r *restful.Request, w *restful.Response) {
+	namespaceName := r.PathParameter("namespace")
 	utils.ListResources(
 		r,
 		w,
 		func(ctx context.Context) (interface{}, error) {
-			return svc.adapter.ListPods(ctx)
+			return svc.adapter.ListPods(ctx, namespaceName)
 		},
-		svc.adapter.GetPodTable,
+		func(ctx context.Context) (*metav1.Table, error) {
+			return svc.adapter.GetPodTable(ctx, namespaceName)
+		},
 	)
 }

--- a/internal/api/core/v1/pods/logs.go
+++ b/internal/api/core/v1/pods/logs.go
@@ -20,6 +20,7 @@ import (
 // the data is immediately sent to the client.
 func (svc PodService) GetPodLogs(r *restful.Request, w *restful.Response) {
 	podName := r.PathParameter("name")
+	namespaceName := r.PathParameter("namespace")
 
 	podLogOptions := adapter.PodLogOptions{
 		Follow:     r.QueryParameter("follow") == "true",
@@ -27,7 +28,7 @@ func (svc PodService) GetPodLogs(r *restful.Request, w *restful.Response) {
 		Tail:       r.QueryParameter("tailLines"),
 	}
 
-	logs, err := svc.adapter.GetPodLogs(context.Background(), podName, podLogOptions)
+	logs, err := svc.adapter.GetPodLogs(context.Background(), namespaceName, podName, podLogOptions)
 	if err != nil {
 		utils.HttpError(r, w, http.StatusInternalServerError, fmt.Errorf("unable to get pod logs: %w", err))
 		return

--- a/internal/api/core/v1/pods/patch.go
+++ b/internal/api/core/v1/pods/patch.go
@@ -16,6 +16,7 @@ import (
 
 func (svc PodService) PatchPod(r *restful.Request, w *restful.Response) {
 	podName := r.PathParameter("name")
+	namespaceName := r.PathParameter("namespace")
 
 	patch, err := io.ReadAll(r.Request.Body)
 	if err != nil {
@@ -23,7 +24,7 @@ func (svc PodService) PatchPod(r *restful.Request, w *restful.Response) {
 		return
 	}
 
-	pod, err := svc.adapter.GetPod(r.Request.Context(), podName)
+	pod, err := svc.adapter.GetPod(r.Request.Context(), podName, namespaceName)
 	if err != nil {
 		utils.HttpError(r, w, http.StatusInternalServerError, fmt.Errorf("unable to get pod: %w", err))
 		return

--- a/internal/api/core/v1/pods/pods.go
+++ b/internal/api/core/v1/pods/pods.go
@@ -31,13 +31,16 @@ func (svc PodService) RegisterPodAPI(ws *restful.WebService) {
 
 	ws.Route(ws.POST("/v1/namespaces/{namespace}/pods").
 		To(svc.CreatePod).
-		Param(ws.QueryParameter("dryRun", "when present, indicates that modifications should not be persisted").DataType("string")))
+		Param(ws.QueryParameter("dryRun", "when present, indicates that modifications should not be persisted").DataType("string")).
+		Param(ws.PathParameter("namespace", "namespace of the deployment").DataType("string")))
 
 	ws.Route(ws.GET("/v1/pods").
 		To(svc.ListPods))
 
 	ws.Route(ws.GET("/v1/namespaces/{namespace}/pods").
-		To(svc.ListPods))
+		To(svc.ListPods).
+		Param(ws.QueryParameter("namespace", "namespace of the deployment").DataType("string")).
+		Param(ws.PathParameter("namespace", "namespace of the deployment").DataType("string")))
 
 	ws.Route(ws.DELETE("/v1/pods/{name}").
 		To(svc.DeletePod).
@@ -45,6 +48,7 @@ func (svc PodService) RegisterPodAPI(ws *restful.WebService) {
 
 	ws.Route(ws.DELETE("/v1/namespaces/{namespace}/pods/{name}").
 		To(svc.DeletePod).
+		Param(ws.PathParameter("namespace", "namespace of the deployment").DataType("string")).
 		Param(ws.PathParameter("name", "name of the pod").DataType("string")))
 
 	ws.Route(ws.GET("/v1/pods/{name}").
@@ -53,6 +57,7 @@ func (svc PodService) RegisterPodAPI(ws *restful.WebService) {
 
 	ws.Route(ws.GET("/v1/namespaces/{namespace}/pods/{name}").
 		To(svc.GetPod).
+		Param(ws.PathParameter("namespace", "namespace of the deployment").DataType("string")).
 		Param(ws.PathParameter("name", "name of the pod").DataType("string")))
 
 	ws.Route(ws.PATCH("/v1/pods/{name}").
@@ -65,12 +70,14 @@ func (svc PodService) RegisterPodAPI(ws *restful.WebService) {
 		To(svc.PatchPod).
 		Param(ws.QueryParameter("dryRun", "when present, indicates that modifications should not be persisted").DataType("string")).
 		AddExtension("x-kubernetes-group-version-kind", podGVKExtension).
+		Param(ws.PathParameter("namespace", "namespace of the deployment").DataType("string")).
 		Param(ws.PathParameter("name", "name of the pod").DataType("string")))
 
 	ws.Route(ws.GET("/v1/namespaces/{namespace}/pods/{name}/log").
 		To(svc.GetPodLogs)).
-		Param(ws.PathParameter("name", "name of the pod").DataType("string")).
 		Param(ws.QueryParameter("follow", "follow the log stream of the pod").DataType("boolean")).
 		Param(ws.QueryParameter("tailLines", "the number of lines from the end of the logs to show").DataType("integer")).
-		Param(ws.QueryParameter("timestamps", "add an RFC3339 or RFC3339Nano timestamp at the beginning of every line of log output").DataType("boolean"))
+		Param(ws.QueryParameter("timestamps", "add an RFC3339 or RFC3339Nano timestamp at the beginning of every line of log output").DataType("boolean")).
+		Param(ws.PathParameter("namespace", "namespace of the pod").DataType("string")).
+		Param(ws.PathParameter("name", "name of the pod").DataType("string"))
 }

--- a/internal/api/core/v1/pods/pods.go
+++ b/internal/api/core/v1/pods/pods.go
@@ -32,15 +32,14 @@ func (svc PodService) RegisterPodAPI(ws *restful.WebService) {
 	ws.Route(ws.POST("/v1/namespaces/{namespace}/pods").
 		To(svc.CreatePod).
 		Param(ws.QueryParameter("dryRun", "when present, indicates that modifications should not be persisted").DataType("string")).
-		Param(ws.PathParameter("namespace", "namespace of the deployment").DataType("string")))
+		Param(ws.PathParameter("namespace", "namespace of the pod").DataType("string")))
 
 	ws.Route(ws.GET("/v1/pods").
 		To(svc.ListPods))
 
 	ws.Route(ws.GET("/v1/namespaces/{namespace}/pods").
 		To(svc.ListPods).
-		Param(ws.QueryParameter("namespace", "namespace of the deployment").DataType("string")).
-		Param(ws.PathParameter("namespace", "namespace of the deployment").DataType("string")))
+		Param(ws.PathParameter("namespace", "namespace of the pod").DataType("string")))
 
 	ws.Route(ws.DELETE("/v1/pods/{name}").
 		To(svc.DeletePod).
@@ -48,7 +47,7 @@ func (svc PodService) RegisterPodAPI(ws *restful.WebService) {
 
 	ws.Route(ws.DELETE("/v1/namespaces/{namespace}/pods/{name}").
 		To(svc.DeletePod).
-		Param(ws.PathParameter("namespace", "namespace of the deployment").DataType("string")).
+		Param(ws.PathParameter("namespace", "namespace of the pod").DataType("string")).
 		Param(ws.PathParameter("name", "name of the pod").DataType("string")))
 
 	ws.Route(ws.GET("/v1/pods/{name}").
@@ -57,7 +56,7 @@ func (svc PodService) RegisterPodAPI(ws *restful.WebService) {
 
 	ws.Route(ws.GET("/v1/namespaces/{namespace}/pods/{name}").
 		To(svc.GetPod).
-		Param(ws.PathParameter("namespace", "namespace of the deployment").DataType("string")).
+		Param(ws.PathParameter("namespace", "namespace of the pod").DataType("string")).
 		Param(ws.PathParameter("name", "name of the pod").DataType("string")))
 
 	ws.Route(ws.PATCH("/v1/pods/{name}").
@@ -70,7 +69,7 @@ func (svc PodService) RegisterPodAPI(ws *restful.WebService) {
 		To(svc.PatchPod).
 		Param(ws.QueryParameter("dryRun", "when present, indicates that modifications should not be persisted").DataType("string")).
 		AddExtension("x-kubernetes-group-version-kind", podGVKExtension).
-		Param(ws.PathParameter("namespace", "namespace of the deployment").DataType("string")).
+		Param(ws.PathParameter("namespace", "namespace of the pod").DataType("string")).
 		Param(ws.PathParameter("name", "name of the pod").DataType("string")))
 
 	ws.Route(ws.GET("/v1/namespaces/{namespace}/pods/{name}/log").

--- a/internal/api/core/v1/services/create.go
+++ b/internal/api/core/v1/services/create.go
@@ -13,12 +13,18 @@ import (
 )
 
 func (svc ServiceService) CreateService(r *restful.Request, w *restful.Response) {
+	namespace := r.PathParameter("namespace")
+
 	service := &corev1.Service{}
 
 	err := httputils.ParseJSONBody(r.Request, &service)
 	if err != nil {
 		utils.HttpError(r, w, http.StatusBadRequest, fmt.Errorf("unable to parse request body: %w", err))
 		return
+	}
+
+	if namespace != "" {
+		service.Namespace = namespace
 	}
 
 	dryRun := r.QueryParameter("dryRun") != ""

--- a/internal/api/core/v1/services/list.go
+++ b/internal/api/core/v1/services/list.go
@@ -5,15 +5,19 @@ import (
 
 	"github.com/emicklei/go-restful/v3"
 	"github.com/portainer/k2d/internal/api/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func (svc ServiceService) ListServices(r *restful.Request, w *restful.Response) {
+	namespaceName := r.PathParameter("namespace")
 	utils.ListResources(
 		r,
 		w,
 		func(ctx context.Context) (interface{}, error) {
-			return svc.adapter.ListServices(ctx)
+			return svc.adapter.ListServices(ctx, namespaceName)
 		},
-		svc.adapter.GetServiceTable,
+		func(ctx context.Context) (*metav1.Table, error) {
+			return svc.adapter.GetServiceTable(ctx, namespaceName)
+		},
 	)
 }

--- a/internal/api/core/v1/services/services.go
+++ b/internal/api/core/v1/services/services.go
@@ -31,13 +31,15 @@ func (svc ServiceService) RegisterServiceAPI(ws *restful.WebService) {
 
 	ws.Route(ws.POST("/v1/namespaces/{namespace}/services").
 		To(svc.CreateService).
+		Param(ws.PathParameter("namespace", "namespace of the service").DataType("string")).
 		Param(ws.QueryParameter("dryRun", "when present, indicates that modifications should not be persisted").DataType("string")))
 
 	ws.Route(ws.GET("/v1/services").
 		To(svc.ListServices))
 
 	ws.Route(ws.GET("/v1/namespaces/{namespace}/services").
-		To(svc.ListServices))
+		To(svc.ListServices).
+		Param(ws.PathParameter("namespace", "namespace of the service").DataType("string")))
 
 	ws.Route(ws.DELETE("/v1/services/{name}").
 		To(svc.DeleteService).
@@ -45,6 +47,7 @@ func (svc ServiceService) RegisterServiceAPI(ws *restful.WebService) {
 
 	ws.Route(ws.DELETE("/v1/namespaces/{namespace}/services/{name}").
 		To(svc.DeleteService).
+		Param(ws.PathParameter("namespace", "namespace of the service").DataType("string")).
 		Param(ws.PathParameter("name", "name of the service").DataType("string")))
 
 	ws.Route(ws.GET("/v1/services/{name}").
@@ -53,6 +56,7 @@ func (svc ServiceService) RegisterServiceAPI(ws *restful.WebService) {
 
 	ws.Route(ws.GET("/v1/namespaces/{namespace}/services/{name}").
 		To(svc.GetService).
+		Param(ws.PathParameter("namespace", "namespace of the service").DataType("string")).
 		Param(ws.PathParameter("name", "name of the service").DataType("string")))
 
 	ws.Route(ws.PATCH("/v1/services/{name}").
@@ -65,5 +69,6 @@ func (svc ServiceService) RegisterServiceAPI(ws *restful.WebService) {
 		To(svc.PatchService).
 		Param(ws.QueryParameter("dryRun", "when present, indicates that modifications should not be persisted").DataType("string")).
 		AddExtension("x-kubernetes-group-version-kind", serviceGVKExtension).
+		Param(ws.PathParameter("namespace", "namespace of the service").DataType("string")).
 		Param(ws.PathParameter("name", "name of the service").DataType("string")))
 }

--- a/internal/api/core/v1/v1.go
+++ b/internal/api/core/v1/v1.go
@@ -28,7 +28,7 @@ func NewV1Service(adapter *adapter.KubeDockerAdapter, operations chan controller
 	return V1Service{
 		configMaps: configmaps.NewConfigMapService(adapter, operations),
 		events:     events.NewEventService(adapter),
-		namespaces: namespaces.NewNamespaceService(adapter),
+		namespaces: namespaces.NewNamespaceService(adapter, operations),
 		nodes:      nodes.NewNodeService(adapter),
 		pods:       pods.NewPodService(adapter, operations),
 		secrets:    secrets.NewSecretService(adapter, operations),
@@ -59,7 +59,7 @@ func (svc V1Service) ListAPIResources(r *restful.Request, w *restful.Response) {
 				Kind:         "Namespace",
 				SingularName: "",
 				Name:         "namespaces",
-				Verbs:        []string{"list", "get"},
+				Verbs:        []string{"create", "list", "delete", "get", "patch"},
 				Namespaced:   false,
 				ShortNames:   []string{"ns"},
 			},

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -168,6 +168,14 @@ func (controller *OperationController) processPriorityOperations(ops []Operation
 
 func (controller *OperationController) processOperation(op Operation) {
 	switch op.Operation.(type) {
+	case *corev1.Namespace:
+		err := controller.createNamespace(op)
+		if err != nil {
+			controller.logger.Errorw("unable to create namespace",
+				"error", err,
+				"request_id", op.RequestID,
+			)
+		}
 	case *corev1.Pod:
 		err := controller.createPod(op)
 		if err != nil {
@@ -207,6 +215,11 @@ func (controller *OperationController) processOperation(op Operation) {
 			)
 		}
 	}
+}
+
+func (controller *OperationController) createNamespace(op Operation) error {
+	namespace := op.Operation.(*corev1.Namespace)
+	return controller.adapter.CreateNetworkFromNamespace(context.TODO(), namespace)
 }
 
 func (controller *OperationController) createPod(op Operation) error {


### PR DESCRIPTION
Partially implements https://github.com/portainer/k2d/issues/13.

**Implementation Details**

- A namespace is equivalent to a Docker Bridge network:
	- Since Docker does not allow creating a Bridge network called `default`, the default is now called `k2d_net`, but it gets translated into `default` wherever required.
- Now, the API operations for `pod`, `deployment`, and `service` accept the namespace parameter, e.g. `kubectl get pods -n namespace`
	- Support for secrets and configMaps once the refactoring is finished.
	- The `-A` all switch is not supported.
- Each container will now be resolvable with the Kubernetes standard service names; `${serviceName}`, `${serviceName}.${namespaceName}`, `${serviceName}.${namespaceName}.svc`, and `${serviceName}.${namespaceName}.svc.cluster.local`:
	- However, due to the design of Docker Bridge networking, where each network becomes an isolated instance, a container won't be able to reach another container on a different Bridge network using these aliases.

**Todo**

- [x] Deleting a namespace (bridge network) used by a container executing `kubectl delete -f` causes issues as the deletion of these objects runs in parallel. Just like creation operations, there might be a need to introduce the `PriorityOperations` for it. This is to be discussed.
- [x] ArgoCD testing.