### PR TITLE
feat: update copy image

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,6 +70,6 @@ type Config struct {
 	// StoreVolumeCopyImageName represents the name of the container image used to copy and read from volumes
 	// when using the volume store for secrets and configmaps.
 	// If not provided through an environment variable named K2D_STORE_VOLUME_COPY_IMAGE_NAME,
-	// the default value is set to docker.io/library/alpine:latest.
-	StoreVolumeCopyImageName string `env:"K2D_STORE_VOLUME_COPY_IMAGE_NAME,default=docker.io/library/alpine:latest"`
+	// the default value is set to portainer/pause:latest.
+	StoreVolumeCopyImageName string `env:"K2D_STORE_VOLUME_COPY_IMAGE_NAME,default=portainer/pause:latest"`
 }


### PR DESCRIPTION
This PR updates the default copy image used by the volume storage to https://hub.docker.com/r/portainer/pause/tags

Related to #20 