### PR TITLE
feat: introduce emulation for sc, pv and pvc

### DIFF
--- a/cmd/k2d.go
+++ b/cmd/k2d.go
@@ -146,6 +146,8 @@ func main() {
 	container.Add(apis.Events())
 	// /apis/authorization.k8s.io
 	container.Add(apis.Authorization())
+	// /apis/storage.k8s.io
+	container.Add(apis.Storages())
 
 	k2d := k2d.NewK2DAPI(serverConfiguration, kubeDockerAdapter)
 	// /k2d/kubeconfig

--- a/internal/adapter/container_utils.go
+++ b/internal/adapter/container_utils.go
@@ -219,6 +219,8 @@ func (adapter *KubeDockerAdapter) getContainer(ctx context.Context, containerNam
 //   - namespace: Used to determine the network in which the container should be created.
 //   - podSpec: The Kubernetes PodSpec that serves as the template for the Docker container.
 //
+// mention about the volume mounts
+//
 // Returns:
 //   - If any step in the container creation process fails (such as PodSpec conversion, image pull, or container creation),
 //     the function returns an error wrapped with a description of the failed step.

--- a/internal/adapter/container_utils.go
+++ b/internal/adapter/container_utils.go
@@ -219,8 +219,6 @@ func (adapter *KubeDockerAdapter) getContainer(ctx context.Context, containerNam
 //   - namespace: Used to determine the network in which the container should be created.
 //   - podSpec: The Kubernetes PodSpec that serves as the template for the Docker container.
 //
-// mention about the volume mounts
-//
 // Returns:
 //   - If any step in the container creation process fails (such as PodSpec conversion, image pull, or container creation),
 //     the function returns an error wrapped with a description of the failed step.

--- a/internal/adapter/converter/pod.go
+++ b/internal/adapter/converter/pod.go
@@ -375,12 +375,14 @@ func (converter *DockerAPIConverter) setVolumeMounts(namespace string, hostConfi
 // For HostPath:
 // The function directly uses the HostPath and volume mount to set up the bind in the Docker host configuration.
 //
+// For PersistentVolumeClaim:
+// The function uses the volume name and namespace to generate a unique name for the volume.
+//
 // Parameters:
 // - hostConfig:   The Docker host configuration where the volume binds will be set.
 // - volume:       The Kubernetes volume object to be processed.
 // - volumeMount:  The Kubernetes volume mount object that provides additional information on how the volume should be mounted.
 //
-// UPDATE WITH PVC
 // Returns:
 // An error if fetching the ConfigMap or Secret from the store fails; otherwise, it returns nil.
 func (converter *DockerAPIConverter) handleVolumeSource(namespace string, hostConfig *container.HostConfig, volume core.Volume, volumeMount core.VolumeMount) error {

--- a/internal/adapter/converter/pod.go
+++ b/internal/adapter/converter/pod.go
@@ -375,6 +375,8 @@ func (converter *DockerAPIConverter) setVolumeMounts(namespace string, hostConfi
 // For HostPath:
 // The function directly uses the HostPath and volume mount to set up the bind in the Docker host configuration.
 //
+// TBU:
+//
 // Parameters:
 // - hostConfig:   The Docker host configuration where the volume binds will be set.
 // - volume:       The Kubernetes volume object to be processed.
@@ -415,6 +417,9 @@ func (converter *DockerAPIConverter) handleVolumeSource(namespace string, hostCo
 		}
 	} else if volume.HostPath != nil {
 		bind := fmt.Sprintf("%s:%s", volume.HostPath.Path, volumeMount.MountPath)
+		hostConfig.Binds = append(hostConfig.Binds, bind)
+	} else if volume.VolumeSource.PersistentVolumeClaim != nil {
+		bind := fmt.Sprintf("%s:%s", fmt.Sprintf("k2d-pv-%s-%s", namespace, volume.VolumeSource.PersistentVolumeClaim.ClaimName), volumeMount.MountPath)
 		hostConfig.Binds = append(hostConfig.Binds, bind)
 	}
 	return nil

--- a/internal/adapter/converter/pod.go
+++ b/internal/adapter/converter/pod.go
@@ -375,13 +375,12 @@ func (converter *DockerAPIConverter) setVolumeMounts(namespace string, hostConfi
 // For HostPath:
 // The function directly uses the HostPath and volume mount to set up the bind in the Docker host configuration.
 //
-// TBU:
-//
 // Parameters:
 // - hostConfig:   The Docker host configuration where the volume binds will be set.
 // - volume:       The Kubernetes volume object to be processed.
 // - volumeMount:  The Kubernetes volume mount object that provides additional information on how the volume should be mounted.
 //
+// UPDATE WITH PVC
 // Returns:
 // An error if fetching the ConfigMap or Secret from the store fails; otherwise, it returns nil.
 func (converter *DockerAPIConverter) handleVolumeSource(namespace string, hostConfig *container.HostConfig, volume core.Volume, volumeMount core.VolumeMount) error {
@@ -419,6 +418,8 @@ func (converter *DockerAPIConverter) handleVolumeSource(namespace string, hostCo
 		bind := fmt.Sprintf("%s:%s", volume.HostPath.Path, volumeMount.MountPath)
 		hostConfig.Binds = append(hostConfig.Binds, bind)
 	} else if volume.VolumeSource.PersistentVolumeClaim != nil {
+		// TODO: Replace the fmt.Sprintf("k2d-pv-%s-%s", namespace, volume.VolumeSource.PersistentVolumeClaim.ClaimName)
+		// part with the buildPersistentVolumeName function.
 		bind := fmt.Sprintf("%s:%s", fmt.Sprintf("k2d-pv-%s-%s", namespace, volume.VolumeSource.PersistentVolumeClaim.ClaimName), volumeMount.MountPath)
 		hostConfig.Binds = append(hostConfig.Binds, bind)
 	}

--- a/internal/adapter/converter/volume.go
+++ b/internal/adapter/converter/volume.go
@@ -16,12 +16,6 @@ func (converter *DockerAPIConverter) ConvertVolumeToPersistentVolume(volume volu
 		return nil, fmt.Errorf("unable to parse volume creation date: %w", err)
 	}
 
-	// TODO: Document it as a limitation
-	// resourceList := core.ResourceList{}
-	// if volume.UsageData != nil {
-	// 	resourceList[core.ResourceStorage] = resource.MustParse(fmt.Sprint(volume.UsageData.Size))
-	// }
-
 	persistentVolumeClaimReference := &core.ObjectReference{
 		Kind:      "PersistentVolumeClaim",
 		Namespace: volume.Labels[k2dtypes.NamespaceLabelKey],

--- a/internal/adapter/converter/volume.go
+++ b/internal/adapter/converter/volume.go
@@ -1,0 +1,60 @@
+package converter
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/docker/docker/api/types/volume"
+	k2dtypes "github.com/portainer/k2d/internal/adapter/types"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (converter *DockerAPIConverter) ConvertVolumeToPersistentVolume(volume volume.Volume) (*corev1.PersistentVolume, error) {
+	creationDate, err := time.Parse(time.RFC3339, volume.CreatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse volume creation date: %w", err)
+	}
+
+	resourceList := corev1.ResourceList{}
+	if volume.UsageData != nil {
+		resourceList[corev1.ResourceStorage] = resource.MustParse(fmt.Sprint(volume.UsageData.Size))
+	}
+
+	// claim reference
+	persistentVolumeClaimReference := &corev1.ObjectReference{
+		Kind:      "PersistentVolumeClaim",
+		Namespace: volume.Labels[k2dtypes.NamespaceLabelKey],
+		Name:      volume.Labels[k2dtypes.PersistentVolumeClaimLabelKey],
+	}
+
+	return &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: volume.Name,
+			CreationTimestamp: metav1.Time{
+				Time: creationDate,
+			},
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "PersistentVolume",
+			APIVersion: "v1",
+		},
+		Spec: corev1.PersistentVolumeSpec{
+			Capacity: resourceList,
+			AccessModes: []corev1.PersistentVolumeAccessMode{
+				corev1.ReadWriteOnce,
+			},
+			PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimDelete,
+			PersistentVolumeSource: corev1.PersistentVolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: volume.Mountpoint,
+				},
+			},
+			ClaimRef: persistentVolumeClaimReference,
+		},
+		Status: corev1.PersistentVolumeStatus{
+			Phase: corev1.VolumeBound,
+		},
+	}, nil
+}

--- a/internal/adapter/namespace.go
+++ b/internal/adapter/namespace.go
@@ -89,6 +89,7 @@ func (adapter *KubeDockerAdapter) DeleteNamespace(ctx context.Context, namespace
 }
 
 func (adapter *KubeDockerAdapter) GetNamespace(ctx context.Context, namespaceName string) (*corev1.Namespace, error) {
+
 	networkName := buildNetworkName(namespaceName)
 
 	network, err := adapter.getNetwork(ctx, networkName)

--- a/internal/adapter/naming.go
+++ b/internal/adapter/naming.go
@@ -7,7 +7,7 @@ import (
 
 // Each container is named using the following format:
 // [namespace]-[container-name]
-func buildContainerName(containerName string, namespace string) string {
+func buildContainerName(containerName, namespace string) string {
 	containerName = strings.TrimPrefix(containerName, "/")
 	return fmt.Sprintf("%s-%s", namespace, containerName)
 }

--- a/internal/adapter/naming.go
+++ b/internal/adapter/naming.go
@@ -7,7 +7,7 @@ import (
 
 // Each container is named using the following format:
 // [namespace]-[container-name]
-func buildContainerName(containerName, namespace string) string {
+func buildContainerName(containerName string, namespace string) string {
 	containerName = strings.TrimPrefix(containerName, "/")
 	return fmt.Sprintf("%s-%s", namespace, containerName)
 }
@@ -16,4 +16,10 @@ func buildContainerName(containerName, namespace string) string {
 // k2d-[namespace]
 func buildNetworkName(namespace string) string {
 	return fmt.Sprintf("k2d-%s", namespace)
+}
+
+// Each persistentVolume is named using the following format:
+// k2d-pv-[namespace]-[volume-name]
+func buildPersistentVolumeName(volumeName string, namespace string) string {
+	return fmt.Sprintf("k2d-pv-%s-%s", namespace, volumeName)
 }

--- a/internal/adapter/persistentvolume.go
+++ b/internal/adapter/persistentvolume.go
@@ -3,14 +3,14 @@ package adapter
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/volume"
+	"github.com/docker/docker/errdefs"
+	adaptererr "github.com/portainer/k2d/internal/adapter/errors"
 	k2dtypes "github.com/portainer/k2d/internal/adapter/types"
 	"github.com/portainer/k2d/internal/k8s"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/apis/core"
 )
@@ -18,10 +18,30 @@ import (
 func (adapter *KubeDockerAdapter) GetPersistentVolume(ctx context.Context, persistentVolumeName string) (*corev1.PersistentVolume, error) {
 	volume, err := adapter.cli.VolumeInspect(ctx, persistentVolumeName)
 	if err != nil {
-		return nil, fmt.Errorf("unable to list volumes to return the output values from a Docker volume: %w", err)
+		if errdefs.IsNotFound(err) {
+			return nil, adaptererr.ErrResourceNotFound
+		}
+		return nil, fmt.Errorf("unable to inspect docker volume %s: %w", persistentVolumeName, err)
 	}
 
-	return adapter.converter.ConvertVolumeToPersistentVolume(volume)
+	persistentVolume, err := adapter.converter.ConvertVolumeToPersistentVolume(volume)
+	if err != nil {
+		return nil, fmt.Errorf("unable to convert Docker volume to PersistentVolume: %w", err)
+	}
+
+	versionedPersistentVolume := corev1.PersistentVolume{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "PersistentVolume",
+			APIVersion: "v1",
+		},
+	}
+
+	err = adapter.ConvertK8SResource(persistentVolume, &versionedPersistentVolume)
+	if err != nil {
+		return nil, fmt.Errorf("unable to convert internal object to versioned object: %w", err)
+	}
+
+	return &versionedPersistentVolume, nil
 }
 
 func (adapter *KubeDockerAdapter) ListPersistentVolumes(ctx context.Context) (core.PersistentVolumeList, error) {
@@ -53,76 +73,13 @@ func (adapter *KubeDockerAdapter) listPersistentVolumes(ctx context.Context) (co
 
 	persistentVolumes := []core.PersistentVolume{}
 
-	for volume := range volumeList.Volumes {
-		creationDate, err := time.Parse(time.RFC3339, volumeList.Volumes[volume].CreatedAt)
+	for _, volume := range volumeList.Volumes {
+		persistentVolume, err := adapter.converter.ConvertVolumeToPersistentVolume(*volume)
 		if err != nil {
-			return core.PersistentVolumeList{}, fmt.Errorf("unable to parse volume creation date: %w", err)
+			return core.PersistentVolumeList{}, fmt.Errorf("unable to convert Docker volume to PersistentVolume: %w", err)
 		}
 
-		resourceList := core.ResourceList{}
-		if volumeList.Volumes[volume].UsageData != nil {
-			resourceList[core.ResourceStorage] = resource.MustParse(fmt.Sprint(volumeList.Volumes[volume].UsageData.Size))
-		}
-
-		persistentClaimReference := &core.ObjectReference{
-			Kind:      "PersistentVolumeClaim",
-			Namespace: volumeList.Volumes[volume].Labels[k2dtypes.NamespaceLabelKey],
-			Name:      volumeList.Volumes[volume].Labels[k2dtypes.PersistentVolumeClaimLabelKey],
-		}
-
-		// TODO: status of the persistent volume has to be retrieved from the
-		// containers that are using it
-
-		// "Mounts": [
-		// 		{
-		// 				"Type": "bind",
-		// 				"Source": "/var/run/docker.sock",
-		// 				"Destination": "/var/run/docker.sock",
-		// 				"Mode": "z",
-		// 				"RW": true,
-		// 				"Propagation": "rprivate"
-		// 		},
-		// 		{
-		// 				"Type": "volume",
-		// 				"Name": "portainer_data",
-		// 				"Source": "/var/lib/docker/volumes/portainer_data/_data",
-		// 				"Destination": "/data",
-		// 				"Driver": "local",
-		// 				"Mode": "z",
-		// 				"RW": true,
-		// 				"Propagation": ""
-		// 		}
-		// ]
-
-		persistentVolumes = append(persistentVolumes, core.PersistentVolume{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: volumeList.Volumes[volume].Name,
-				CreationTimestamp: metav1.Time{
-					Time: creationDate,
-				},
-			},
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "PersistentVolume",
-				APIVersion: "v1",
-			},
-			Spec: core.PersistentVolumeSpec{
-				Capacity: resourceList,
-				AccessModes: []core.PersistentVolumeAccessMode{
-					core.ReadWriteOnce,
-				},
-				PersistentVolumeReclaimPolicy: core.PersistentVolumeReclaimDelete,
-				PersistentVolumeSource: core.PersistentVolumeSource{
-					HostPath: &core.HostPathVolumeSource{
-						Path: volumeList.Volumes[volume].Mountpoint,
-					},
-				},
-				ClaimRef:         persistentClaimReference,
-				StorageClassName: "local",
-			},
-			Status: core.PersistentVolumeStatus{
-				Phase: core.VolumeBound,
-			},
-		})
+		persistentVolumes = append(persistentVolumes, *persistentVolume)
 	}
 
 	return core.PersistentVolumeList{

--- a/internal/adapter/persistentvolume.go
+++ b/internal/adapter/persistentvolume.go
@@ -1,0 +1,180 @@
+package adapter
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/volume"
+	k2dtypes "github.com/portainer/k2d/internal/adapter/types"
+	"github.com/portainer/k2d/internal/k8s"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/apis/core"
+)
+
+func (adapter *KubeDockerAdapter) GetPersistentVolume(ctx context.Context, persistentVolumeName string) (*corev1.PersistentVolume, error) {
+	labelFilter := filters.NewArgs()
+	labelFilter.Add("name", persistentVolumeName)
+	labelFilter.Add("label", fmt.Sprintf("%s=%s", k2dtypes.PersistentVolumeLabelKey, persistentVolumeName))
+
+	volumeList, err := adapter.cli.VolumeList(ctx, volume.ListOptions{Filters: labelFilter})
+	if err != nil {
+		return nil, fmt.Errorf("unable to list volumes to return the output values from a Docker volume: %w", err)
+	}
+
+	if len(volumeList.Volumes) > 0 {
+		creationDate, err := time.Parse(time.RFC3339, volumeList.Volumes[0].CreatedAt)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse volume creation date: %w", err)
+		}
+
+		resourceList := corev1.ResourceList{}
+		if volumeList.Volumes[0].UsageData != nil {
+			resourceList[corev1.ResourceStorage] = resource.MustParse(fmt.Sprint(volumeList.Volumes[0].UsageData.Size))
+		}
+
+		return &corev1.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: volumeList.Volumes[0].Name,
+				CreationTimestamp: metav1.Time{
+					Time: creationDate,
+				},
+			},
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "PersistentVolume",
+				APIVersion: "v1",
+			},
+			Spec: corev1.PersistentVolumeSpec{
+				Capacity: resourceList,
+				AccessModes: []corev1.PersistentVolumeAccessMode{
+					corev1.ReadWriteOnce,
+				},
+				PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimDelete,
+				PersistentVolumeSource: corev1.PersistentVolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: volumeList.Volumes[0].Mountpoint,
+					},
+				},
+				ClaimRef: nil,
+			},
+			Status: corev1.PersistentVolumeStatus{
+				Phase: corev1.VolumeBound,
+			},
+		}, nil
+	}
+
+	return nil, nil
+}
+
+func (adapter *KubeDockerAdapter) ListPersistentVolumes(ctx context.Context) (core.PersistentVolumeList, error) {
+	persistentVolumes, err := adapter.listPersistentVolumes(ctx)
+	if err != nil {
+		return core.PersistentVolumeList{}, fmt.Errorf("unable to list nodes: %w", err)
+	}
+
+	return persistentVolumes, nil
+}
+
+func (adapter *KubeDockerAdapter) GetPersistentVolumeTable(ctx context.Context) (*metav1.Table, error) {
+	persistentVolumeList, err := adapter.listPersistentVolumes(ctx)
+	if err != nil {
+		return &metav1.Table{}, fmt.Errorf("unable to list nodes: %w", err)
+	}
+
+	return k8s.GenerateTable(&persistentVolumeList)
+}
+
+func (adapter *KubeDockerAdapter) listPersistentVolumes(ctx context.Context) (core.PersistentVolumeList, error) {
+	labelFilter := filters.NewArgs()
+	labelFilter.Add("label", k2dtypes.PersistentVolumeLabelKey)
+
+	volumeList, err := adapter.cli.VolumeList(ctx, volume.ListOptions{Filters: labelFilter})
+	if err != nil {
+		return core.PersistentVolumeList{}, fmt.Errorf("unable to list volumes to return the output values from a Docker volume: %w", err)
+	}
+
+	persistentVolumes := []core.PersistentVolume{}
+
+	for volume := range volumeList.Volumes {
+		creationDate, err := time.Parse(time.RFC3339, volumeList.Volumes[volume].CreatedAt)
+		if err != nil {
+			return core.PersistentVolumeList{}, fmt.Errorf("unable to parse volume creation date: %w", err)
+		}
+
+		resourceList := core.ResourceList{}
+		if volumeList.Volumes[volume].UsageData != nil {
+			resourceList[core.ResourceStorage] = resource.MustParse(fmt.Sprint(volumeList.Volumes[volume].UsageData.Size))
+		}
+
+		persistentClaimReference := &core.ObjectReference{
+			Kind:      "PersistentVolumeClaim",
+			Namespace: volumeList.Volumes[volume].Labels[k2dtypes.NamespaceLabelKey],
+			Name:      volumeList.Volumes[volume].Labels[k2dtypes.PersistentVolumeClaimLabelKey],
+		}
+
+		// TODO: status of the persistent volume has to be retrieved from the
+		// containers that are using it
+
+		// "Mounts": [
+		// 		{
+		// 				"Type": "bind",
+		// 				"Source": "/var/run/docker.sock",
+		// 				"Destination": "/var/run/docker.sock",
+		// 				"Mode": "z",
+		// 				"RW": true,
+		// 				"Propagation": "rprivate"
+		// 		},
+		// 		{
+		// 				"Type": "volume",
+		// 				"Name": "portainer_data",
+		// 				"Source": "/var/lib/docker/volumes/portainer_data/_data",
+		// 				"Destination": "/data",
+		// 				"Driver": "local",
+		// 				"Mode": "z",
+		// 				"RW": true,
+		// 				"Propagation": ""
+		// 		}
+		// ]
+
+		persistentVolumes = append(persistentVolumes, core.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: volumeList.Volumes[volume].Name,
+				CreationTimestamp: metav1.Time{
+					Time: creationDate,
+				},
+			},
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "PersistentVolume",
+				APIVersion: "v1",
+			},
+			Spec: core.PersistentVolumeSpec{
+				Capacity: resourceList,
+				AccessModes: []core.PersistentVolumeAccessMode{
+					core.ReadWriteOnce,
+				},
+				PersistentVolumeReclaimPolicy: core.PersistentVolumeReclaimDelete,
+				PersistentVolumeSource: core.PersistentVolumeSource{
+					HostPath: &core.HostPathVolumeSource{
+						Path: volumeList.Volumes[volume].Mountpoint,
+					},
+				},
+				ClaimRef:         persistentClaimReference,
+				StorageClassName: "local",
+			},
+			Status: core.PersistentVolumeStatus{
+				Phase: core.VolumeBound,
+			},
+		})
+	}
+
+	return core.PersistentVolumeList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "PersistentVolumeList",
+			APIVersion: "v1",
+		},
+		Items: persistentVolumes,
+	}, nil
+}

--- a/internal/adapter/persistentvolumeclaim.go
+++ b/internal/adapter/persistentvolumeclaim.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/volume"
+	"github.com/docker/docker/errdefs"
 	adaptererr "github.com/portainer/k2d/internal/adapter/errors"
 	k2dtypes "github.com/portainer/k2d/internal/adapter/types"
 	"github.com/portainer/k2d/internal/k8s"
@@ -34,9 +34,6 @@ func (adapter *KubeDockerAdapter) CreatePersistentVolumeClaim(ctx context.Contex
 			k2dtypes.PersistentVolumeClaimLabelKey:                  persistentVolumeClaim.Name,
 			k2dtypes.PersistentVolumeClaimLastAppliedConfigLabelKey: persistentVolumeClaim.ObjectMeta.Annotations["kubectl.kubernetes.io/last-applied-configuration"],
 		},
-		// DriverOpts: map[string]string{
-		// 	"o": "size" + persistentVolumeClaim.Spec.Resources.Requests.Storage().String(),
-		// },
 	})
 
 	if err != nil {
@@ -58,87 +55,54 @@ func (adapter *KubeDockerAdapter) DeletePersistentVolumeClaim(ctx context.Contex
 }
 
 func (adapter *KubeDockerAdapter) GetPersistentVolumeClaim(ctx context.Context, persistentVolumeClaimName string, namespaceName string) (*corev1.PersistentVolumeClaim, error) {
-	labelFilter := filters.NewArgs()
-	labelFilter.Add("name", persistentVolumeClaimName)
-	labelFilter.Add("label", fmt.Sprintf("%s=%s", k2dtypes.NamespaceLabelKey, namespaceName))
-
-	volumes, err := adapter.cli.VolumeList(ctx, volume.ListOptions{Filters: labelFilter})
+	volumeName := buildPersistentVolumeName(persistentVolumeClaimName, namespaceName)
+	volume, err := adapter.cli.VolumeInspect(ctx, volumeName)
 	if err != nil {
-		return nil, fmt.Errorf("unable to list volumes to return the output values from a Docker volume: %w", err)
+		if errdefs.IsNotFound(err) {
+			return nil, adaptererr.ErrResourceNotFound
+		}
+		return nil, fmt.Errorf("unable to inspect docker volume %s: %w", volumeName, err)
 	}
 
-	if len(volumes.Volumes) == 0 {
-		return nil, adaptererr.ErrResourceNotFound
-	}
-
-	if len(volumes.Volumes) > 1 {
-		return nil, fmt.Errorf("multiple volumes were found with the associated persistent volume claim name %s", persistentVolumeClaimName)
-	}
-
-	persistentVolumeClaim, err := adapter.buildPersistentVolumeClaimFromVolume(*volumes.Volumes[0])
+	persistentVolumeClaim, err := adapter.buildPersistentVolumeClaimFromVolume(volume)
 	if err != nil {
 		return nil, fmt.Errorf("unable to build persistent volume claim from volume: %w", err)
 	}
 
-	return persistentVolumeClaim, nil
-}
-
-func (adapter *KubeDockerAdapter) buildPersistentVolumeClaimFromVolume(volume volume.Volume) (*corev1.PersistentVolumeClaim, error) {
-	if volume.Labels[k2dtypes.PersistentVolumeClaimLastAppliedConfigLabelKey] == "" {
-		return nil, fmt.Errorf("unable to build deployment, missing %s label on container %s", k2dtypes.PersistentVolumeClaimLastAppliedConfigLabelKey, volume.Name)
-	}
-
-	persistentVolumeClaimData := volume.Labels[k2dtypes.PersistentVolumeClaimLastAppliedConfigLabelKey]
-
-	versionedPersistentVolumeClaim := corev1.PersistentVolumeClaim{}
-
-	err := json.Unmarshal([]byte(persistentVolumeClaimData), &versionedPersistentVolumeClaim)
-	if err != nil {
-		return nil, fmt.Errorf("unable to unmarshal persistent volume claim: %w", err)
-	}
-
-	persistentVolumeClaim := corev1.PersistentVolumeClaim{}
-	err = adapter.ConvertK8SResource(&versionedPersistentVolumeClaim, &persistentVolumeClaim)
-	if err != nil {
-		return nil, fmt.Errorf("unable to convert versioned deployment spec to internal persistent volume claim spec: %w", err)
-	}
-
-	creationDate, err := time.Parse(time.RFC3339, volume.CreatedAt)
-	if err != nil {
-		return &corev1.PersistentVolumeClaim{}, fmt.Errorf("unable to parse volume creation date: %w", err)
-	}
-
-	storageClassName := "local"
-
-	return &corev1.PersistentVolumeClaim{
+	versionedPersistentVolumeClaim := corev1.PersistentVolumeClaim{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PersistentVolumeClaim",
 			APIVersion: "v1",
 		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      volume.Labels[k2dtypes.PersistentVolumeClaimLabelKey],
-			Namespace: volume.Labels[k2dtypes.NamespaceLabelKey],
-			CreationTimestamp: metav1.Time{
-				Time: creationDate,
-			},
-			Annotations: map[string]string{
-				"kubectl.kubernetes.io/last-applied-configuration": volume.Labels[k2dtypes.PersistentVolumeClaimLastAppliedConfigLabelKey],
-			},
-		},
-		Spec: corev1.PersistentVolumeClaimSpec{
-			StorageClassName: &storageClassName,
-			VolumeName:       buildPersistentVolumeName(volume.Labels[k2dtypes.PersistentVolumeClaimLabelKey], volume.Labels[k2dtypes.NamespaceLabelKey]),
-			AccessModes: []corev1.PersistentVolumeAccessMode{
-				corev1.ReadWriteOnce,
-			},
-		},
-		Status: corev1.PersistentVolumeClaimStatus{
-			Phase: corev1.ClaimBound,
-			AccessModes: []corev1.PersistentVolumeAccessMode{
-				corev1.ReadWriteOnce,
-			},
-		},
-	}, nil
+	}
+
+	err = adapter.ConvertK8SResource(persistentVolumeClaim, &versionedPersistentVolumeClaim)
+	if err != nil {
+		return nil, fmt.Errorf("unable to convert internal object to versioned object: %w", err)
+	}
+
+	return &versionedPersistentVolumeClaim, nil
+}
+
+func (adapter *KubeDockerAdapter) buildPersistentVolumeClaimFromVolume(volume volume.Volume) (*core.PersistentVolumeClaim, error) {
+	persistentVolumeClaim, err := adapter.converter.ConvertVolumeToPersistentVolumeClaim(volume)
+	if err != nil {
+		return nil, fmt.Errorf("unable to convert Docker volume to PersistentVolumeClaim: %w", err)
+	}
+
+	if volume.Labels[k2dtypes.PersistentVolumeClaimLastAppliedConfigLabelKey] != "" {
+		internalPersistentVolumeClaimData := volume.Labels[k2dtypes.PersistentVolumeClaimLastAppliedConfigLabelKey]
+		persistentVolumeClaimSpec := core.PersistentVolumeClaimSpec{}
+
+		err := json.Unmarshal([]byte(internalPersistentVolumeClaimData), &persistentVolumeClaimSpec)
+		if err != nil {
+			return nil, fmt.Errorf("unable to unmarshal pod spec: %w", err)
+		}
+
+		persistentVolumeClaim.Spec = persistentVolumeClaimSpec
+	}
+
+	return persistentVolumeClaim, nil
 }
 
 func (adapter *KubeDockerAdapter) ListPersistentVolumeClaims(ctx context.Context, namespaceName string) (core.PersistentVolumeClaimList, error) {
@@ -147,7 +111,7 @@ func (adapter *KubeDockerAdapter) ListPersistentVolumeClaims(ctx context.Context
 		return core.PersistentVolumeClaimList{}, fmt.Errorf("unable to list persistent volume claims: %w", err)
 	}
 
-	return persistentVolumeClaims, nil
+	return *persistentVolumeClaims, nil
 }
 
 func (adapter *KubeDockerAdapter) GetPersistentVolumeClaimTable(ctx context.Context, namespaceName string) (*metav1.Table, error) {
@@ -156,17 +120,17 @@ func (adapter *KubeDockerAdapter) GetPersistentVolumeClaimTable(ctx context.Cont
 		return &metav1.Table{}, fmt.Errorf("unable to list nodes: %w", err)
 	}
 
-	return k8s.GenerateTable(&persistentVolumeClaims)
+	return k8s.GenerateTable(persistentVolumeClaims)
 }
 
-func (adapter *KubeDockerAdapter) listPersistentVolumeClaims(ctx context.Context, namespaceName string) (core.PersistentVolumeClaimList, error) {
+func (adapter *KubeDockerAdapter) listPersistentVolumeClaims(ctx context.Context, namespaceName string) (*core.PersistentVolumeClaimList, error) {
 	labelFilter := filters.NewArgs()
 	labelFilter.Add("label", k2dtypes.PersistentVolumeClaimLabelKey)
 	labelFilter.Add("label", fmt.Sprintf("%s=%s", k2dtypes.NamespaceLabelKey, namespaceName))
 
 	volumeList, err := adapter.cli.VolumeList(ctx, volume.ListOptions{Filters: labelFilter})
 	if err != nil {
-		return core.PersistentVolumeClaimList{}, fmt.Errorf("unable to list volumes to return the output values from a Docker volume: %w", err)
+		return &core.PersistentVolumeClaimList{}, fmt.Errorf("unable to list volumes to return the output values from a Docker volume: %w", err)
 	}
 
 	persistentVolumeClaims := core.PersistentVolumeClaimList{
@@ -176,43 +140,14 @@ func (adapter *KubeDockerAdapter) listPersistentVolumeClaims(ctx context.Context
 		},
 	}
 
-	// TODO: storage class name determination
-
 	for _, volume := range volumeList.Volumes {
-		creationDate, err := time.Parse(time.RFC3339, volume.CreatedAt)
+		persistentVolumeClaim, err := adapter.converter.ConvertVolumeToPersistentVolumeClaim(*volume)
 		if err != nil {
-			return core.PersistentVolumeClaimList{}, fmt.Errorf("unable to parse volume creation date: %w", err)
+			return nil, fmt.Errorf("unable to convert Docker volume to PersistentVolumeClaim: %w", err)
 		}
 
-		storageClassName := "local"
-
-		persistentVolumeClaims.Items = append(persistentVolumeClaims.Items, core.PersistentVolumeClaim{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      volume.Labels[k2dtypes.PersistentVolumeClaimLabelKey],
-				Namespace: namespaceName,
-				CreationTimestamp: metav1.Time{
-					Time: creationDate,
-				},
-			},
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "PersistentVolumeClaim",
-				APIVersion: "v1",
-			},
-			Spec: core.PersistentVolumeClaimSpec{
-				StorageClassName: &storageClassName,
-				VolumeName:       buildPersistentVolumeName(volume.Labels[k2dtypes.PersistentVolumeClaimLabelKey], namespaceName),
-				AccessModes: []core.PersistentVolumeAccessMode{
-					core.ReadWriteOnce,
-				},
-			},
-			Status: core.PersistentVolumeClaimStatus{
-				Phase: core.ClaimBound,
-				AccessModes: []core.PersistentVolumeAccessMode{
-					core.ReadWriteOnce,
-				},
-			},
-		})
+		persistentVolumeClaims.Items = append(persistentVolumeClaims.Items, *persistentVolumeClaim)
 	}
 
-	return persistentVolumeClaims, nil
+	return &persistentVolumeClaims, nil
 }

--- a/internal/adapter/persistentvolumeclaim.go
+++ b/internal/adapter/persistentvolumeclaim.go
@@ -1,0 +1,218 @@
+package adapter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/volume"
+	adaptererr "github.com/portainer/k2d/internal/adapter/errors"
+	k2dtypes "github.com/portainer/k2d/internal/adapter/types"
+	"github.com/portainer/k2d/internal/k8s"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/apis/core"
+)
+
+func (adapter *KubeDockerAdapter) CreatePersistentVolumeClaim(ctx context.Context, persistentVolumeClaim *corev1.PersistentVolumeClaim) error {
+	if persistentVolumeClaim.Labels["app.kubernetes.io/managed-by"] == "Helm" {
+		persistentVolumeClaimData, err := json.Marshal(persistentVolumeClaim)
+		if err != nil {
+			return fmt.Errorf("unable to marshal deployment: %w", err)
+		}
+		persistentVolumeClaim.ObjectMeta.Annotations["kubectl.kubernetes.io/last-applied-configuration"] = string(persistentVolumeClaimData)
+	}
+
+	_, err := adapter.cli.VolumeCreate(ctx, volume.CreateOptions{
+		Name:   buildPersistentVolumeName(persistentVolumeClaim.Name, persistentVolumeClaim.Namespace),
+		Driver: "local",
+		Labels: map[string]string{
+			k2dtypes.NamespaceLabelKey:                              persistentVolumeClaim.Namespace,
+			k2dtypes.PersistentVolumeLabelKey:                       buildPersistentVolumeName(persistentVolumeClaim.Name, persistentVolumeClaim.Namespace),
+			k2dtypes.PersistentVolumeClaimLabelKey:                  persistentVolumeClaim.Name,
+			k2dtypes.PersistentVolumeClaimLastAppliedConfigLabelKey: persistentVolumeClaim.ObjectMeta.Annotations["kubectl.kubernetes.io/last-applied-configuration"],
+		},
+		// DriverOpts: map[string]string{
+		// 	"o": "size" + persistentVolumeClaim.Spec.Resources.Requests.Storage().String(),
+		// },
+	})
+
+	if err != nil {
+		return fmt.Errorf("unable to create a Docker volume for the request persistent volume claim: %w", err)
+	}
+
+	return nil
+}
+
+func (adapter *KubeDockerAdapter) DeletePersistentVolumeClaim(ctx context.Context, persistentVolumeClaimName string, namespaceName string) error {
+	persistentVolumeName := buildPersistentVolumeName(persistentVolumeClaimName, namespaceName)
+
+	err := adapter.cli.VolumeRemove(ctx, persistentVolumeName, true)
+	if err != nil {
+		return fmt.Errorf("unable to remove Docker volume: %w", err)
+	}
+
+	return nil
+}
+
+func (adapter *KubeDockerAdapter) GetPersistentVolumeClaim(ctx context.Context, persistentVolumeClaimName string, namespaceName string) (*corev1.PersistentVolumeClaim, error) {
+	labelFilter := filters.NewArgs()
+	labelFilter.Add("name", persistentVolumeClaimName)
+	labelFilter.Add("label", fmt.Sprintf("%s=%s", k2dtypes.NamespaceLabelKey, namespaceName))
+
+	volumes, err := adapter.cli.VolumeList(ctx, volume.ListOptions{Filters: labelFilter})
+	if err != nil {
+		return nil, fmt.Errorf("unable to list volumes to return the output values from a Docker volume: %w", err)
+	}
+
+	if len(volumes.Volumes) == 0 {
+		return nil, adaptererr.ErrResourceNotFound
+	}
+
+	if len(volumes.Volumes) > 1 {
+		return nil, fmt.Errorf("multiple volumes were found with the associated persistent volume claim name %s", persistentVolumeClaimName)
+	}
+
+	persistentVolumeClaim, err := adapter.buildPersistentVolumeClaimFromVolume(*volumes.Volumes[0])
+	if err != nil {
+		return nil, fmt.Errorf("unable to build persistent volume claim from volume: %w", err)
+	}
+
+	return persistentVolumeClaim, nil
+}
+
+func (adapter *KubeDockerAdapter) buildPersistentVolumeClaimFromVolume(volume volume.Volume) (*corev1.PersistentVolumeClaim, error) {
+	if volume.Labels[k2dtypes.PersistentVolumeClaimLastAppliedConfigLabelKey] == "" {
+		return nil, fmt.Errorf("unable to build deployment, missing %s label on container %s", k2dtypes.PersistentVolumeClaimLastAppliedConfigLabelKey, volume.Name)
+	}
+
+	persistentVolumeClaimData := volume.Labels[k2dtypes.PersistentVolumeClaimLastAppliedConfigLabelKey]
+
+	versionedPersistentVolumeClaim := corev1.PersistentVolumeClaim{}
+
+	err := json.Unmarshal([]byte(persistentVolumeClaimData), &versionedPersistentVolumeClaim)
+	if err != nil {
+		return nil, fmt.Errorf("unable to unmarshal persistent volume claim: %w", err)
+	}
+
+	persistentVolumeClaim := corev1.PersistentVolumeClaim{}
+	err = adapter.ConvertK8SResource(&versionedPersistentVolumeClaim, &persistentVolumeClaim)
+	if err != nil {
+		return nil, fmt.Errorf("unable to convert versioned deployment spec to internal persistent volume claim spec: %w", err)
+	}
+
+	creationDate, err := time.Parse(time.RFC3339, volume.CreatedAt)
+	if err != nil {
+		return &corev1.PersistentVolumeClaim{}, fmt.Errorf("unable to parse volume creation date: %w", err)
+	}
+
+	storageClassName := "local"
+
+	return &corev1.PersistentVolumeClaim{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "PersistentVolumeClaim",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      volume.Labels[k2dtypes.PersistentVolumeClaimLabelKey],
+			Namespace: volume.Labels[k2dtypes.NamespaceLabelKey],
+			CreationTimestamp: metav1.Time{
+				Time: creationDate,
+			},
+			Annotations: map[string]string{
+				"kubectl.kubernetes.io/last-applied-configuration": volume.Labels[k2dtypes.PersistentVolumeClaimLastAppliedConfigLabelKey],
+			},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &storageClassName,
+			VolumeName:       buildPersistentVolumeName(volume.Labels[k2dtypes.PersistentVolumeClaimLabelKey], volume.Labels[k2dtypes.NamespaceLabelKey]),
+			AccessModes: []corev1.PersistentVolumeAccessMode{
+				corev1.ReadWriteOnce,
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			Phase: corev1.ClaimBound,
+			AccessModes: []corev1.PersistentVolumeAccessMode{
+				corev1.ReadWriteOnce,
+			},
+		},
+	}, nil
+}
+
+func (adapter *KubeDockerAdapter) ListPersistentVolumeClaims(ctx context.Context, namespaceName string) (core.PersistentVolumeClaimList, error) {
+	persistentVolumeClaims, err := adapter.listPersistentVolumeClaims(ctx, namespaceName)
+	if err != nil {
+		return core.PersistentVolumeClaimList{}, fmt.Errorf("unable to list persistent volume claims: %w", err)
+	}
+
+	return persistentVolumeClaims, nil
+}
+
+func (adapter *KubeDockerAdapter) GetPersistentVolumeClaimTable(ctx context.Context, namespaceName string) (*metav1.Table, error) {
+	persistentVolumeClaims, err := adapter.listPersistentVolumeClaims(ctx, namespaceName)
+	if err != nil {
+		return &metav1.Table{}, fmt.Errorf("unable to list nodes: %w", err)
+	}
+
+	return k8s.GenerateTable(&persistentVolumeClaims)
+}
+
+func (adapter *KubeDockerAdapter) listPersistentVolumeClaims(ctx context.Context, namespaceName string) (core.PersistentVolumeClaimList, error) {
+	labelFilter := filters.NewArgs()
+	labelFilter.Add("label", k2dtypes.PersistentVolumeClaimLabelKey)
+	labelFilter.Add("label", fmt.Sprintf("%s=%s", k2dtypes.NamespaceLabelKey, namespaceName))
+
+	volumeList, err := adapter.cli.VolumeList(ctx, volume.ListOptions{Filters: labelFilter})
+	if err != nil {
+		return core.PersistentVolumeClaimList{}, fmt.Errorf("unable to list volumes to return the output values from a Docker volume: %w", err)
+	}
+
+	persistentVolumeClaims := core.PersistentVolumeClaimList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "PersistentVolumeClaimList",
+			APIVersion: "v1",
+		},
+	}
+
+	// TODO: storage class name determination
+
+	for _, volume := range volumeList.Volumes {
+		creationDate, err := time.Parse(time.RFC3339, volume.CreatedAt)
+		if err != nil {
+			return core.PersistentVolumeClaimList{}, fmt.Errorf("unable to parse volume creation date: %w", err)
+		}
+
+		storageClassName := "local"
+
+		persistentVolumeClaims.Items = append(persistentVolumeClaims.Items, core.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      volume.Labels[k2dtypes.PersistentVolumeClaimLabelKey],
+				Namespace: namespaceName,
+				CreationTimestamp: metav1.Time{
+					Time: creationDate,
+				},
+			},
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "PersistentVolumeClaim",
+				APIVersion: "v1",
+			},
+			Spec: core.PersistentVolumeClaimSpec{
+				StorageClassName: &storageClassName,
+				VolumeName:       buildPersistentVolumeName(volume.Labels[k2dtypes.PersistentVolumeClaimLabelKey], namespaceName),
+				AccessModes: []core.PersistentVolumeAccessMode{
+					core.ReadWriteOnce,
+				},
+			},
+			Status: core.PersistentVolumeClaimStatus{
+				Phase: core.ClaimBound,
+				AccessModes: []core.PersistentVolumeAccessMode{
+					core.ReadWriteOnce,
+				},
+			},
+		})
+	}
+
+	return persistentVolumeClaims, nil
+}

--- a/internal/adapter/storageclass.go
+++ b/internal/adapter/storageclass.go
@@ -1,0 +1,83 @@
+package adapter
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/portainer/k2d/internal/k8s"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/apis/storage"
+)
+
+func (adapter *KubeDockerAdapter) GetStorageClass(ctx context.Context, storageClassName string) (*storagev1.StorageClass, error) {
+	info, _, err := adapter.InfoAndVersion(ctx)
+	if err != nil {
+		return &storagev1.StorageClass{}, err
+	}
+
+	for _, plugin := range info.Plugins.Volume {
+		if plugin == storageClassName {
+			return &storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: plugin,
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "StorageClass",
+					APIVersion: "storage.k8s.io/v1",
+				},
+				Provisioner: plugin,
+			}, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func (adapter *KubeDockerAdapter) ListStorageClasses(ctx context.Context) (storage.StorageClassList, error) {
+	storageClassList, err := adapter.listStorageClasses(ctx)
+	if err != nil {
+		return storage.StorageClassList{}, fmt.Errorf("unable to list storageClasses: %w", err)
+	}
+
+	return storageClassList, nil
+}
+
+func (adapter *KubeDockerAdapter) GetStorageClassTable(ctx context.Context) (*metav1.Table, error) {
+	storageClassList, err := adapter.listStorageClasses(ctx)
+	if err != nil {
+		return &metav1.Table{}, fmt.Errorf("unable to list storageClasses: %w", err)
+	}
+
+	return k8s.GenerateTable(&storageClassList)
+}
+
+func (adapter *KubeDockerAdapter) listStorageClasses(ctx context.Context) (storage.StorageClassList, error) {
+	info, _, err := adapter.InfoAndVersion(ctx)
+	if err != nil {
+		return storage.StorageClassList{}, err
+	}
+
+	storageClasses := []storage.StorageClass{}
+
+	for _, plugin := range info.Plugins.Volume {
+		storageClasses = append(storageClasses, storage.StorageClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: plugin,
+			},
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "StorageClass",
+				APIVersion: "storage.k8s.io/v1",
+			},
+			Provisioner: plugin,
+		})
+	}
+
+	return storage.StorageClassList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "StorageClassList",
+			APIVersion: "storage.k8s.io/v1",
+		},
+		Items: storageClasses,
+	}, nil
+}

--- a/internal/adapter/types/labels.go
+++ b/internal/adapter/types/labels.go
@@ -16,6 +16,9 @@ const (
 	// ServiceLastAppliedConfigLabelKey is the key used to store the service specific last applied configuration in the container labels
 	ServiceLastAppliedConfigLabelKey = "service.k2d.io/last-applied-configuration"
 
+	// PersistentVolumeClaimLastAppliedConfigLabelKey is the key used to store the service specific last applied configuration in the container labels
+	PersistentVolumeClaimLastAppliedConfigLabelKey = "persistentvolumeclaim.k2d.io/last-applied-configuration"
+
 	// ServiceNameLabelKey is the key used to store the service name in the container labels
 	ServiceNameLabelKey = "workload.k2d.io/service-name"
 
@@ -27,4 +30,10 @@ const (
 
 	// WorkloadNameLabelKey is the key used to store the workload name in the container labels
 	WorkloadNameLabelKey = "workload.k2d.io/name"
+
+	// PersistentVolumeLabelKey is the key used to store the persistent volume name in the container labels
+	PersistentVolumeLabelKey = "persistentvolume.k2d.io/name"
+
+	// PersistentVolumeClaimLabelKey is the key used to store the persistent volume name in the container labels
+	PersistentVolumeClaimLabelKey = "persistentvolumeclaim.k2d.io/name"
 )

--- a/internal/adapter/types/labels.go
+++ b/internal/adapter/types/labels.go
@@ -32,8 +32,8 @@ const (
 	WorkloadNameLabelKey = "workload.k2d.io/name"
 
 	// PersistentVolumeLabelKey is the key used to store the persistent volume name in the container labels
-	PersistentVolumeLabelKey = "persistentvolume.k2d.io/name"
+	PersistentVolumeLabelKey = "storage.k2d.io/pv"
 
 	// PersistentVolumeClaimLabelKey is the key used to store the persistent volume name in the container labels
-	PersistentVolumeClaimLabelKey = "persistentvolumeclaim.k2d.io/name"
+	PersistentVolumeClaimLabelKey = "storage.k2d.io/pvc"
 )

--- a/internal/api/apis/apigroups_list.go
+++ b/internal/api/apis/apigroups_list.go
@@ -39,6 +39,15 @@ func ListAPIGroups(r *restful.Request, w *restful.Response) {
 					},
 				},
 			},
+			{
+				Name: "storage.k8s.io",
+				Versions: []metav1.GroupVersionForDiscovery{
+					{
+						GroupVersion: "storage.k8s.io/v1",
+						Version:      "v1",
+					},
+				},
+			},
 		},
 	}
 

--- a/internal/api/apis/apis.go
+++ b/internal/api/apis/apis.go
@@ -46,7 +46,6 @@ func (api ApisAPI) APIs() *restful.WebService {
 func (api ApisAPI) Storages() *restful.WebService {
 	routes := new(restful.WebService).
 		Path("/apis/storage.k8s.io").
-		Consumes(restful.MIME_JSON).
 		Produces(restful.MIME_JSON)
 
 	// which versions are served by this api

--- a/internal/api/apis/storage.k8s.io/storage.go
+++ b/internal/api/apis/storage.k8s.io/storage.go
@@ -1,0 +1,56 @@
+package storage
+
+import (
+	"github.com/emicklei/go-restful/v3"
+	"github.com/portainer/k2d/internal/adapter"
+	"github.com/portainer/k2d/internal/api/apis/storage.k8s.io/storageclasses"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type StorageService struct {
+	storageclasses storageclasses.StorageClassService
+}
+
+func NewStorageService(adapter *adapter.KubeDockerAdapter) StorageService {
+	return StorageService{
+		storageclasses: storageclasses.NewStorageClassService(adapter),
+	}
+}
+
+func (svc StorageService) GetAPIVersions(r *restful.Request, w *restful.Response) {
+	apiVersion := metav1.APIVersions{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "APIVersions",
+		},
+		Versions: []string{"storage.k8s.io/v1"},
+	}
+
+	w.WriteAsJson(apiVersion)
+}
+
+func (svc StorageService) ListAPIResources(r *restful.Request, w *restful.Response) {
+	resourceList := metav1.APIResourceList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "APIResourceList",
+			APIVersion: "v1",
+		},
+		GroupVersion: "storage.k8s.io/v1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:         "StorageClass",
+				SingularName: "",
+				Name:         "storageclasses",
+				ShortNames:   []string{"sc"},
+				Verbs:        []string{"get,list"},
+				Namespaced:   false,
+			},
+		},
+	}
+
+	w.WriteAsJson(resourceList)
+}
+
+func (svc StorageService) RegisterStorageAPI(routes *restful.WebService) {
+	// storage
+	svc.storageclasses.RegisterDeploymentAPI(routes)
+}

--- a/internal/api/apis/storage.k8s.io/storage.go
+++ b/internal/api/apis/storage.k8s.io/storage.go
@@ -52,5 +52,5 @@ func (svc StorageService) ListAPIResources(r *restful.Request, w *restful.Respon
 
 func (svc StorageService) RegisterStorageAPI(routes *restful.WebService) {
 	// storage
-	svc.storageclasses.RegisterDeploymentAPI(routes)
+	svc.storageclasses.RegisterStorageClassAPI(routes)
 }

--- a/internal/api/apis/storage.k8s.io/storageclasses/get.go
+++ b/internal/api/apis/storage.k8s.io/storageclasses/get.go
@@ -1,0 +1,26 @@
+package storageclasses
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/emicklei/go-restful/v3"
+	"github.com/portainer/k2d/internal/api/utils"
+)
+
+func (svc StorageClassService) GetStorageClass(r *restful.Request, w *restful.Response) {
+	storageClassName := r.PathParameter("name")
+
+	sc, err := svc.adapter.GetStorageClass(r.Request.Context(), storageClassName)
+	if err != nil {
+		utils.HttpError(r, w, http.StatusInternalServerError, fmt.Errorf("unable to get the storage class: %w", err))
+		return
+	}
+
+	if sc == nil {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	w.WriteAsJson(sc)
+}

--- a/internal/api/apis/storage.k8s.io/storageclasses/list.go
+++ b/internal/api/apis/storage.k8s.io/storageclasses/list.go
@@ -1,0 +1,22 @@
+package storageclasses
+
+import (
+	"context"
+
+	"github.com/emicklei/go-restful/v3"
+	"github.com/portainer/k2d/internal/api/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (svc StorageClassService) ListStorageClass(r *restful.Request, w *restful.Response) {
+	utils.ListResources(
+		r,
+		w,
+		func(ctx context.Context) (interface{}, error) {
+			return svc.adapter.ListStorageClasses(r.Request.Context())
+		},
+		func(ctx context.Context) (*metav1.Table, error) {
+			return svc.adapter.GetStorageClassTable(r.Request.Context())
+		},
+	)
+}

--- a/internal/api/apis/storage.k8s.io/storageclasses/storageclass.go
+++ b/internal/api/apis/storage.k8s.io/storageclasses/storageclass.go
@@ -15,7 +15,7 @@ func NewStorageClassService(adapter *adapter.KubeDockerAdapter) StorageClassServ
 	}
 }
 
-func (svc StorageClassService) RegisterDeploymentAPI(ws *restful.WebService) {
+func (svc StorageClassService) RegisterStorageClassAPI(ws *restful.WebService) {
 	ws.Route(ws.GET("/v1/storageclasses").
 		To(svc.ListStorageClass))
 

--- a/internal/api/apis/storage.k8s.io/storageclasses/storageclass.go
+++ b/internal/api/apis/storage.k8s.io/storageclasses/storageclass.go
@@ -1,0 +1,25 @@
+package storageclasses
+
+import (
+	"github.com/emicklei/go-restful/v3"
+	"github.com/portainer/k2d/internal/adapter"
+)
+
+type StorageClassService struct {
+	adapter *adapter.KubeDockerAdapter
+}
+
+func NewStorageClassService(adapter *adapter.KubeDockerAdapter) StorageClassService {
+	return StorageClassService{
+		adapter: adapter,
+	}
+}
+
+func (svc StorageClassService) RegisterDeploymentAPI(ws *restful.WebService) {
+	ws.Route(ws.GET("/v1/storageclasses").
+		To(svc.ListStorageClass))
+
+	ws.Route(ws.GET("/v1/storageclasses/{name}").
+		To(svc.GetStorageClass).
+		Param(ws.PathParameter("name", "name of the storageclass").DataType("string")))
+}

--- a/internal/api/core/v1/persistentvolumeclaims/create.go
+++ b/internal/api/core/v1/persistentvolumeclaims/create.go
@@ -1,0 +1,36 @@
+package persistentvolumeclaims
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/emicklei/go-restful/v3"
+	"github.com/portainer/k2d/internal/api/utils"
+	"github.com/portainer/k2d/internal/controller"
+	"github.com/portainer/k2d/internal/types"
+	httputils "github.com/portainer/k2d/pkg/http"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func (svc PersistentVolumeClaimService) CreatePersistentVolumeClaim(r *restful.Request, w *restful.Response) {
+	namespace := r.PathParameter("namespace")
+	persistentVolumeClaim := &corev1.PersistentVolumeClaim{}
+
+	err := httputils.ParseJSONBody(r.Request, &persistentVolumeClaim)
+	if err != nil {
+		utils.HttpError(r, w, http.StatusBadRequest, fmt.Errorf("unable to parse request body: %w", err))
+		return
+	}
+
+	persistentVolumeClaim.Namespace = namespace
+
+	dryRun := r.QueryParameter("dryRun") != ""
+	if dryRun {
+		w.WriteAsJson(persistentVolumeClaim)
+		return
+	}
+
+	svc.operations <- controller.NewOperation(persistentVolumeClaim, controller.HighPriorityOperation, r.HeaderParameter(types.RequestIDHeader))
+
+	w.WriteAsJson(persistentVolumeClaim)
+}

--- a/internal/api/core/v1/persistentvolumeclaims/delete.go
+++ b/internal/api/core/v1/persistentvolumeclaims/delete.go
@@ -1,0 +1,30 @@
+package persistentvolumeclaims
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/emicklei/go-restful/v3"
+	"github.com/portainer/k2d/internal/api/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (svc PersistentVolumeClaimService) DeletePersistentVolumeClaim(r *restful.Request, w *restful.Response) {
+	namespace := r.PathParameter("namespace")
+	persistentVolumeClaimName := r.PathParameter("name")
+
+	err := svc.adapter.DeletePersistentVolumeClaim(r.Request.Context(), persistentVolumeClaimName, namespace)
+	if err != nil {
+		utils.HttpError(r, w, http.StatusInternalServerError, fmt.Errorf("unable to delete network: %w", err))
+		return
+	}
+
+	w.WriteAsJson(metav1.Status{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Status",
+			APIVersion: "v1",
+		},
+		Status: "Success",
+		Code:   http.StatusOK,
+	})
+}

--- a/internal/api/core/v1/persistentvolumeclaims/get.go
+++ b/internal/api/core/v1/persistentvolumeclaims/get.go
@@ -1,0 +1,29 @@
+package persistentvolumeclaims
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/emicklei/go-restful/v3"
+	adaptererr "github.com/portainer/k2d/internal/adapter/errors"
+	"github.com/portainer/k2d/internal/api/utils"
+)
+
+func (svc PersistentVolumeClaimService) GetPersistentVolumeClaim(r *restful.Request, w *restful.Response) {
+	namespace := r.PathParameter("namespace")
+	persistentVolumeClaimName := r.PathParameter("name")
+
+	persistentVolumeClaim, err := svc.adapter.GetPersistentVolumeClaim(r.Request.Context(), persistentVolumeClaimName, namespace)
+	if err != nil {
+		if errors.Is(err, adaptererr.ErrResourceNotFound) {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		utils.HttpError(r, w, http.StatusInternalServerError, fmt.Errorf("unable to get persistent volume claim: %w", err))
+		return
+	}
+
+	w.WriteAsJson(persistentVolumeClaim)
+}

--- a/internal/api/core/v1/persistentvolumeclaims/list.go
+++ b/internal/api/core/v1/persistentvolumeclaims/list.go
@@ -1,0 +1,24 @@
+package persistentvolumeclaims
+
+import (
+	"context"
+
+	"github.com/emicklei/go-restful/v3"
+	"github.com/portainer/k2d/internal/api/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (svc PersistentVolumeClaimService) ListPersistentVolumeClaims(r *restful.Request, w *restful.Response) {
+	namespace := r.PathParameter("namespace")
+
+	utils.ListResources(
+		r,
+		w,
+		func(ctx context.Context) (interface{}, error) {
+			return svc.adapter.ListPersistentVolumeClaims(ctx, namespace)
+		},
+		func(ctx context.Context) (*metav1.Table, error) {
+			return svc.adapter.GetPersistentVolumeClaimTable(ctx, namespace)
+		},
+	)
+}

--- a/internal/api/core/v1/persistentvolumeclaims/patch.go
+++ b/internal/api/core/v1/persistentvolumeclaims/patch.go
@@ -1,0 +1,62 @@
+package persistentvolumeclaims
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/emicklei/go-restful/v3"
+	"github.com/portainer/k2d/internal/api/utils"
+	"github.com/portainer/k2d/internal/controller"
+	"github.com/portainer/k2d/internal/types"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+)
+
+func (svc PersistentVolumeClaimService) PatchPersistentVolumeClaim(r *restful.Request, w *restful.Response) {
+	namespace := r.PathParameter("namespace")
+	persistentVolumeClaimName := r.PathParameter("name")
+
+	patch, err := io.ReadAll(r.Request.Body)
+	if err != nil {
+		utils.HttpError(r, w, http.StatusBadRequest, fmt.Errorf("unable to parse request body: %w", err))
+		return
+	}
+
+	persistentVolumeClaim, err := svc.adapter.GetPersistentVolumeClaim(r.Request.Context(), persistentVolumeClaimName, namespace)
+	if err != nil {
+		utils.HttpError(r, w, http.StatusInternalServerError, fmt.Errorf("unable to get persistent volume claim: %w", err))
+		return
+	}
+
+	data, err := json.Marshal(persistentVolumeClaim)
+	if err != nil {
+		utils.HttpError(r, w, http.StatusInternalServerError, fmt.Errorf("unable to marshal persistent volume claim: %w", err))
+		return
+	}
+
+	mergedData, err := strategicpatch.StrategicMergePatch(data, patch, corev1.PersistentVolumeClaim{})
+	if err != nil {
+		utils.HttpError(r, w, http.StatusInternalServerError, fmt.Errorf("unable to apply patch: %w", err))
+		return
+	}
+
+	updatedPersistentVolumeClaim := &corev1.PersistentVolumeClaim{}
+
+	err = json.Unmarshal(mergedData, updatedPersistentVolumeClaim)
+	if err != nil {
+		utils.HttpError(r, w, http.StatusInternalServerError, fmt.Errorf("unable to unmarshal namespace: %w", err))
+		return
+	}
+
+	dryRun := r.QueryParameter("dryRun") != ""
+	if dryRun {
+		w.WriteAsJson(updatedPersistentVolumeClaim)
+		return
+	}
+
+	svc.operations <- controller.NewOperation(updatedPersistentVolumeClaim, controller.HighPriorityOperation, r.HeaderParameter(types.RequestIDHeader))
+
+	w.WriteAsJson(updatedPersistentVolumeClaim)
+}

--- a/internal/api/core/v1/persistentvolumeclaims/persistentvolumeclaims.go
+++ b/internal/api/core/v1/persistentvolumeclaims/persistentvolumeclaims.go
@@ -1,0 +1,74 @@
+package persistentvolumeclaims
+
+import (
+	"github.com/emicklei/go-restful/v3"
+	"github.com/portainer/k2d/internal/adapter"
+	"github.com/portainer/k2d/internal/controller"
+)
+
+type PersistentVolumeClaimService struct {
+	adapter    *adapter.KubeDockerAdapter
+	operations chan controller.Operation
+}
+
+func NewPersistentVolumeClaimService(adapter *adapter.KubeDockerAdapter, operations chan controller.Operation) PersistentVolumeClaimService {
+	return PersistentVolumeClaimService{
+		adapter:    adapter,
+		operations: operations,
+	}
+}
+
+func (svc PersistentVolumeClaimService) RegisterPersistentVolumeClaimAPI(ws *restful.WebService) {
+	persistentVolumeClaimGVKExtension := map[string]string{
+		"group":   "",
+		"kind":    "PersistentVolumeClaim",
+		"version": "v1",
+	}
+
+	ws.Route(ws.POST("/v1/persistentvolumeclaims").
+		To(svc.CreatePersistentVolumeClaim).
+		Param(ws.QueryParameter("dryRun", "when present, indicates that modifications should not be persisted").DataType("string")))
+
+	ws.Route(ws.POST("/v1/namespaces/{namespace}/persistentvolumeclaims").
+		To(svc.CreatePersistentVolumeClaim).
+		Param(ws.PathParameter("namespace", "namespace name").DataType("string")).
+		Param(ws.QueryParameter("dryRun", "when present, indicates that modifications should not be persisted").DataType("string")))
+
+	ws.Route(ws.GET("/v1/persistentvolumeclaims").
+		To(svc.ListPersistentVolumeClaims))
+
+	ws.Route(ws.GET("/v1/persistentvolumeclaims/{name}").
+		To(svc.GetPersistentVolumeClaim).
+		Param(ws.PathParameter("name", "name of the persistentvolumeclaims").DataType("string")))
+
+	ws.Route(ws.GET("/v1/namespaces/{namespace}/persistentvolumeclaims").
+		To(svc.ListPersistentVolumeClaims).
+		Param(ws.PathParameter("namespace", "namespace name").DataType("string")))
+
+	ws.Route(ws.GET("/v1/namespaces/{namespace}/persistentvolumeclaims/{name}").
+		To(svc.GetPersistentVolumeClaim).
+		Param(ws.PathParameter("namespace", "namespace name").DataType("string")).
+		Param(ws.PathParameter("name", "name of the persistentvolumeclaim").DataType("string")))
+
+	ws.Route(ws.DELETE("/v1/persistentvolumeclaims/{name}").
+		To(svc.DeletePersistentVolumeClaim).
+		Param(ws.PathParameter("name", "name of the persistentvolumeclaim").DataType("string")))
+
+	ws.Route(ws.DELETE("/v1/namespaces/{namespace}/persistentvolumeclaims/{name}").
+		To(svc.DeletePersistentVolumeClaim).
+		Param(ws.PathParameter("namespace", "namespace name").DataType("string")).
+		Param(ws.PathParameter("name", "name of the persistentvolumeclaim").DataType("string")))
+
+	ws.Route(ws.PATCH("/v1/persistentvolumeclaims/{name}").
+		To(svc.PatchPersistentVolumeClaim).
+		Param(ws.PathParameter("name", "name of the persistentvolumeclaim").DataType("string")).
+		Param(ws.QueryParameter("dryRun", "when present, indicates that modifications should not be persisted").DataType("string")).
+		AddExtension("x-kubernetes-group-version-kind", persistentVolumeClaimGVKExtension))
+
+	ws.Route(ws.PATCH("/v1/namespaces/{namespace}/persistentvolumeclaims/{name}").
+		To(svc.PatchPersistentVolumeClaim).
+		Param(ws.PathParameter("namespace", "namespace name").DataType("string")).
+		Param(ws.PathParameter("name", "name of the persistentvolumeclaim").DataType("string")).
+		Param(ws.QueryParameter("dryRun", "when present, indicates that modifications should not be persisted").DataType("string")).
+		AddExtension("x-kubernetes-group-version-kind", persistentVolumeClaimGVKExtension))
+}

--- a/internal/api/core/v1/persistentvolumes/get.go
+++ b/internal/api/core/v1/persistentvolumes/get.go
@@ -1,0 +1,26 @@
+package persistentvolumes
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/emicklei/go-restful/v3"
+	"github.com/portainer/k2d/internal/api/utils"
+)
+
+func (svc PersistentVolumeService) GetPersistentVolume(r *restful.Request, w *restful.Response) {
+	persistentVolumeName := r.PathParameter("name")
+
+	persistentVolume, err := svc.adapter.GetPersistentVolume(r.Request.Context(), persistentVolumeName)
+	if err != nil {
+		utils.HttpError(r, w, http.StatusInternalServerError, fmt.Errorf("unable to get persistentVolume: %w", err))
+		return
+	}
+
+	if persistentVolume == nil {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	w.WriteAsJson(persistentVolume)
+}

--- a/internal/api/core/v1/persistentvolumes/get.go
+++ b/internal/api/core/v1/persistentvolumes/get.go
@@ -1,10 +1,12 @@
 package persistentvolumes
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
 	"github.com/emicklei/go-restful/v3"
+	adaptererr "github.com/portainer/k2d/internal/adapter/errors"
 	"github.com/portainer/k2d/internal/api/utils"
 )
 
@@ -13,12 +15,12 @@ func (svc PersistentVolumeService) GetPersistentVolume(r *restful.Request, w *re
 
 	persistentVolume, err := svc.adapter.GetPersistentVolume(r.Request.Context(), persistentVolumeName)
 	if err != nil {
-		utils.HttpError(r, w, http.StatusInternalServerError, fmt.Errorf("unable to get persistentVolume: %w", err))
-		return
-	}
+		if errors.Is(err, adaptererr.ErrResourceNotFound) {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
 
-	if persistentVolume == nil {
-		w.WriteHeader(http.StatusNotFound)
+		utils.HttpError(r, w, http.StatusInternalServerError, fmt.Errorf("unable to get persistent volume: %w", err))
 		return
 	}
 

--- a/internal/api/core/v1/persistentvolumes/list.go
+++ b/internal/api/core/v1/persistentvolumes/list.go
@@ -1,0 +1,22 @@
+package persistentvolumes
+
+import (
+	"context"
+
+	"github.com/emicklei/go-restful/v3"
+	"github.com/portainer/k2d/internal/api/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (svc PersistentVolumeService) ListPersistentVolumes(r *restful.Request, w *restful.Response) {
+	utils.ListResources(
+		r,
+		w,
+		func(ctx context.Context) (interface{}, error) {
+			return svc.adapter.ListPersistentVolumes(ctx)
+		},
+		func(ctx context.Context) (*metav1.Table, error) {
+			return svc.adapter.GetPersistentVolumeTable(ctx)
+		},
+	)
+}

--- a/internal/api/core/v1/persistentvolumes/persistentvolumes.go
+++ b/internal/api/core/v1/persistentvolumes/persistentvolumes.go
@@ -1,0 +1,25 @@
+package persistentvolumes
+
+import (
+	"github.com/emicklei/go-restful/v3"
+	"github.com/portainer/k2d/internal/adapter"
+)
+
+type PersistentVolumeService struct {
+	adapter *adapter.KubeDockerAdapter
+}
+
+func NewPersistentVolumeService(adapter *adapter.KubeDockerAdapter) PersistentVolumeService {
+	return PersistentVolumeService{
+		adapter: adapter,
+	}
+}
+
+func (svc PersistentVolumeService) RegisterPersistentVolumeAPI(ws *restful.WebService) {
+	ws.Route(ws.GET("/v1/persistentvolumes").
+		To(svc.ListPersistentVolumes))
+
+	ws.Route(ws.GET("/v1/persistentvolumes/{name}").
+		To(svc.GetPersistentVolume).
+		Param(ws.PathParameter("name", "name of the persistentvolume").DataType("string")))
+}

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -214,6 +214,14 @@ func (controller *OperationController) processOperation(op Operation) {
 				"request_id", op.RequestID,
 			)
 		}
+	case *corev1.PersistentVolumeClaim:
+		err := controller.createPersistentVolumeClaim(op)
+		if err != nil {
+			controller.logger.Errorw("unable to update persistent volume claim",
+				"error", err,
+				"request_id", op.RequestID,
+			)
+		}
 	}
 }
 
@@ -245,4 +253,9 @@ func (controller *OperationController) createConfigMap(op Operation) error {
 func (controller *OperationController) createSecret(op Operation) error {
 	secret := op.Operation.(*corev1.Secret)
 	return controller.adapter.CreateSecret(secret)
+}
+
+func (controller *OperationController) createPersistentVolumeClaim(op Operation) error {
+	persistentVolumeClaim := op.Operation.(*corev1.PersistentVolumeClaim)
+	return controller.adapter.CreatePersistentVolumeClaim(context.TODO(), persistentVolumeClaim)
 }


### PR DESCRIPTION
Closes https://github.com/portainer/k2d/issues/12.

**Implementation Details**

In Kubernetes, `Storage Class`, `Persistent Volume Claim`, and `Persistent Volume` are generally used for storage. Translating these to the Docker terms:

- Storage Class = Volume Plugins
	- This can be expanded to other plugins, such as CSI drivers, in future
- Persistent Volume Claim = N/A
- Persistent Volume = Docker Volume

Unlike Kubernetes, where a storage class can be defined as a manifest, creating a Volume plugin on demand is impossible at the Docker layer. Hence, only the `GET` and `LIST` operations will be added, defaulting to the `local` Docker Volume driver only as a starting point.

Since there is no concept of Persistent Volume Claim in Docker, the decision was to merge PV and PVC into Docker Volume. This means that the creation and deletion of a Docker Volume are only activated via PVC (dynamic PV creation). The user will not be able to create a PV and statically map it to a PVC. Rather, you can rely on the PVC to dynamically provision a PV, which is a Docker Volume in the backend.

Due to Docker Volume's immutable nature, for instance, updating its labels requires a complete recreation; the reclaim policy is set to `Delete`. There is a separate discussion to change the default policy to `Retain`.

The details of PVC are stored as a Docker Volume label, and PV is directly obtained from the specification of a Docker Volume.

Finally, mounting a PVC to a pod is equivalent to a Docker volume mount; `docker run -v ${DOCKER_VOLUME}:/${PATH}`.