### PR TITLE
feat: support name parameter for get node operation

### DIFF
--- a/internal/api/core/v1/nodes/get.go
+++ b/internal/api/core/v1/nodes/get.go
@@ -1,23 +1,27 @@
 package nodes
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
 	"github.com/emicklei/go-restful/v3"
+	adaptererr "github.com/portainer/k2d/internal/adapter/errors"
+
 	"github.com/portainer/k2d/internal/api/utils"
 )
 
 func (svc NodeService) GetNode(r *restful.Request, w *restful.Response) {
-	// TODO: introduce get node with name support
-	node, err := svc.adapter.GetNode(r.Request.Context())
-	if err != nil {
-		utils.HttpError(r, w, http.StatusInternalServerError, fmt.Errorf("unable to get node: %w", err))
-		return
-	}
+	name := r.PathParameter("name")
 
-	if node == nil {
-		w.WriteHeader(http.StatusNotFound)
+	node, err := svc.adapter.GetNode(r.Request.Context(), name)
+	if err != nil {
+		if errors.Is(err, adaptererr.ErrResourceNotFound) {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		utils.HttpError(r, w, http.StatusInternalServerError, fmt.Errorf("unable to get namespace: %w", err))
 		return
 	}
 


### PR DESCRIPTION
This PR implements support for the node name for the node get operation.

This allows to inspect the node via the node, e.g. `kubectl get node nodeName` and will return an error not found when specifying an invalid node name.