### PR TITLE
feat: introduce encrypted volume store support

### DIFF
--- a/internal/adapter/container_utils.go
+++ b/internal/adapter/container_utils.go
@@ -367,7 +367,7 @@ func (adapter *KubeDockerAdapter) getRegistryCredentials(podSpec corev1.PodSpec,
 
 	registryURL := reference.Domain(parsed)
 
-	adapter.logger.Infof("retrieving private registry credentials",
+	adapter.logger.Infow("retrieving private registry credentials",
 		"container_image", imageName,
 		"registry", registryURL,
 	)
@@ -376,12 +376,12 @@ func (adapter *KubeDockerAdapter) getRegistryCredentials(podSpec corev1.PodSpec,
 
 	registrySecret, err := adapter.registrySecretStore.GetSecret(pullSecret.Name, namespace)
 	if err != nil {
-		return "", fmt.Errorf("unable to get registry secret: %w", err)
+		return "", fmt.Errorf("unable to get registry secret %s: %w", pullSecret.Name, err)
 	}
 
 	username, password, err := k8s.GetRegistryAuthFromSecret(registrySecret, registryURL)
 	if err != nil {
-		return "", fmt.Errorf("unable to decode registry secret: %w", err)
+		return "", fmt.Errorf("unable to decode registry secret %s: %w", pullSecret.Name, err)
 	}
 
 	authConfig := registry.AuthConfig{

--- a/internal/adapter/store/store.go
+++ b/internal/adapter/store/store.go
@@ -117,8 +117,6 @@ func ConfigureRegistrySecretStore(opts StoreOptions, encryptionKeyFolder string)
 	case "memory":
 		return memory.NewInMemoryStore(), nil
 	case "volume":
-
-		// TODO: generate or retrieve the encryption key from here
 		encryptionKey, err := volume.GenerateOrRetrieveEncryptionKey(opts.Logger, encryptionKeyFolder)
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate encryption key: %w", err)

--- a/internal/adapter/store/volume/configmap.go
+++ b/internal/adapter/store/volume/configmap.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/errdefs"
 	"github.com/portainer/k2d/internal/adapter/errors"
+	"github.com/portainer/k2d/internal/adapter/types"
 	"github.com/portainer/k2d/pkg/maputils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -162,8 +163,8 @@ func (store *VolumeStore) StoreConfigMap(configMap *corev1.ConfigMap) error {
 	volumeName := buildConfigMapVolumeName(configMap.Name, configMap.Namespace)
 
 	labels := map[string]string{
-		ResourceTypeLabelKey:  ConfigMapResourceType,
-		NamespaceNameLabelKey: configMap.Namespace,
+		ResourceTypeLabelKey:    ConfigMapResourceType,
+		types.NamespaceLabelKey: configMap.Namespace,
 	}
 	maputils.MergeMapsInPlace(labels, configMap.Labels)
 
@@ -186,7 +187,7 @@ func (store *VolumeStore) StoreConfigMap(configMap *corev1.ConfigMap) error {
 // createConfigMapFromVolume constructs a Kubernetes ConfigMap object from a Docker volume.
 // Returns a ConfigMap object, and an error if any occurs (e.g., if the volume's creation timestamp is not parseable).
 func createConfigMapFromVolume(volume *volume.Volume) (core.ConfigMap, error) {
-	namespace := volume.Labels[NamespaceNameLabelKey]
+	namespace := volume.Labels[types.NamespaceLabelKey]
 
 	configMap := core.ConfigMap{
 		TypeMeta: metav1.TypeMeta{

--- a/internal/adapter/store/volume/copy.go
+++ b/internal/adapter/store/volume/copy.go
@@ -17,32 +17,27 @@ import (
 
 // copyDataMapToVolume is responsible for copying a given data map into a specified Docker volume.
 // It creates a temporary container, mounts the volume, and then populates it with data.
+// If an encryption key is provided, it also encrypts the data before copying.
 //
 // Parameters:
 // - volumeName: The target Docker volume where the data will be copied.
 // - dataMap: A map where the keys are file names and the values are file contents.
 //
 // Returns:
-// - Returns an error if any step in the pipeline (container creation, data copying, or container removal) fails.
+// - Returns an error if any step in the pipeline (container creation, data encryption, data copying, or container removal) fails.
+//
+// Implementation Details:
+// - Creates a temporary container for data copying, with the target Docker volume mounted.
+// - Optionally encrypts the data using the encryption key, if provided.
+// - Writes the (possibly encrypted) data to a tar archive.
+// - Copies the tar archive to the temporary container.
+// - Removes the temporary container after data copying is complete.
 func (s *VolumeStore) copyDataMapToVolume(volumeName string, dataMap map[string]string) error {
-	containerConfig := &container.Config{
-		Image: s.copyImageName,
-	}
-	hostConfig := &container.HostConfig{
-		Binds: []string{
-			fmt.Sprintf("%s:%s", volumeName, WorkingDirName),
-		},
-	}
-
+	volumeBinds := []string{fmt.Sprintf("%s:%s", volumeName, WorkingDirName)}
 	copyContainerName := fmt.Sprintf("k2d-volume-copy-%s-%d", volumeName, time.Now().UnixNano())
-	resp, err := s.cli.ContainerCreate(context.TODO(), containerConfig, hostConfig, nil, nil, copyContainerName)
+	containerID, err := s.createAndStartCopyContainer(volumeBinds, copyContainerName)
 	if err != nil {
 		return fmt.Errorf("unable to create temporary volume copy container: %w", err)
-	}
-
-	err = s.cli.ContainerStart(context.TODO(), resp.ID, types.ContainerStartOptions{})
-	if err != nil {
-		return fmt.Errorf("unable to start temporary volume copy container: %w", err)
 	}
 
 	var buf bytes.Buffer
@@ -73,12 +68,12 @@ func (s *VolumeStore) copyDataMapToVolume(volumeName string, dataMap map[string]
 		return fmt.Errorf("unable to close tar writer: %w", err)
 	}
 
-	err = s.cli.CopyToContainer(context.TODO(), resp.ID, WorkingDirName, &buf, types.CopyToContainerOptions{})
+	err = s.cli.CopyToContainer(context.TODO(), containerID, WorkingDirName, &buf, types.CopyToContainerOptions{})
 	if err != nil {
 		return fmt.Errorf("unable to copy data to temporary volume copy container: %w", err)
 	}
 
-	err = s.cli.ContainerRemove(context.Background(), resp.ID, types.ContainerRemoveOptions{
+	err = s.cli.ContainerRemove(context.TODO(), containerID, types.ContainerRemoveOptions{
 		Force: true,
 	})
 	if err != nil {
@@ -92,17 +87,17 @@ func (s *VolumeStore) copyDataMapToVolume(volumeName string, dataMap map[string]
 // The container is used for data copying operations.
 //
 // Parameters:
-// - volumeBindings: A list of volume bindings, which are strings that specify the volumes to attach to the container.
+// - volumeBinds: A list of volume bindings, which are strings that specify the volumes to attach to the container.
 // - containerName: The name to give to the temporary container.
 //
 // Returns:
 // - The ID of the newly created container or an error if the container creation fails.
-func (s *VolumeStore) createAndStartCopyContainer(volumeBindings []string, containerName string) (string, error) {
+func (s *VolumeStore) createAndStartCopyContainer(volumeBinds []string, containerName string) (string, error) {
 	containerConfig := &container.Config{
 		Image: s.copyImageName,
 	}
 	hostConfig := &container.HostConfig{
-		Binds: volumeBindings,
+		Binds: volumeBinds,
 	}
 
 	resp, err := s.cli.ContainerCreate(context.TODO(), containerConfig, hostConfig, nil, nil, containerName)
@@ -117,17 +112,23 @@ func (s *VolumeStore) createAndStartCopyContainer(volumeBindings []string, conta
 	return resp.ID, nil
 }
 
-// getDataMapFromVolume extracts the data stored in a specific Docker volume and returns it as a map.
+// getDataMapFromVolume extracts and optionally decrypts the data stored in a specific Docker volume and returns it as a map.
 // This function creates a temporary container with the volume mounted to extract the data.
 //
 // Parameters:
 // - volumeName: The name of the Docker volume from which to extract data.
 //
 // Returns:
-// - A map where the keys are filenames and the values are file contents, or an error if the operation fails.
+// - A map where the keys are filenames and the values are file contents.
+// - An error if the operation fails.
+//
+// Implementation Details:
+// - A temporary container is created to read from the mounted volume.
+// - If an encryption key is provided, the data is decrypted before being returned.
 func (store *VolumeStore) getDataMapFromVolume(volumeName string) (map[string]string, error) {
 	copyContainerName := fmt.Sprintf("k2d-volume-read-%s-%d", volumeName, time.Now().UnixNano())
-	containerID, err := store.createAndStartCopyContainer([]string{fmt.Sprintf("%s:%s", volumeName, WorkingDirName)}, copyContainerName)
+	volumeBinds := []string{fmt.Sprintf("%s:%s", volumeName, WorkingDirName)}
+	containerID, err := store.createAndStartCopyContainer(volumeBinds, copyContainerName)
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +138,7 @@ func (store *VolumeStore) getDataMapFromVolume(volumeName string) (map[string]st
 		return nil, err
 	}
 
-	err = store.cli.ContainerRemove(context.Background(), containerID, types.ContainerRemoveOptions{Force: true})
+	err = store.cli.ContainerRemove(context.TODO(), containerID, types.ContainerRemoveOptions{Force: true})
 	if err != nil {
 		return nil, err
 	}
@@ -145,8 +146,8 @@ func (store *VolumeStore) getDataMapFromVolume(volumeName string) (map[string]st
 	return parseTarToMap(content, store.encryptionKey)
 }
 
-// getDataMapsFromVolumes extracts the data stored in multiple Docker volumes and returns it as a map of maps.
-// It creates a single temporary container, mounts all specified volumes, and then extracts data from them.
+// getDataMapsFromVolumes extracts and optionally decrypts the data stored in multiple Docker volumes and returns it as a map of maps.
+// A single temporary container is created, multiple volumes are mounted, and data is extracted from them.
 //
 // Parameters:
 // - volumeNames: A list of Docker volume names from which to extract data.
@@ -154,14 +155,18 @@ func (store *VolumeStore) getDataMapFromVolume(volumeName string) (map[string]st
 // Returns:
 // - A map where each key is a volume name and the corresponding value is a map containing that volume's data.
 // - An error if the operation fails.
+//
+// Implementation Details:
+// - A single temporary container is created to read from multiple mounted volumes.
+// - If an encryption key is provided, the data from each volume is decrypted before being returned.
 func (store *VolumeStore) getDataMapsFromVolumes(volumeNames []string) (map[string]map[string]string, error) {
-	var binds []string
+	var volumeBinds []string
 	for _, volumeName := range volumeNames {
-		binds = append(binds, fmt.Sprintf("%s:%s", volumeName, path.Join(WorkingDirName, volumeName)))
+		volumeBinds = append(volumeBinds, fmt.Sprintf("%s:%s", volumeName, path.Join(WorkingDirName, volumeName)))
 	}
 
 	copyContainerName := fmt.Sprintf("k2d-volume-read-%d", time.Now().UnixNano())
-	containerID, err := store.createAndStartCopyContainer(binds, copyContainerName)
+	containerID, err := store.createAndStartCopyContainer(volumeBinds, copyContainerName)
 	if err != nil {
 		return nil, err
 	}
@@ -190,14 +195,19 @@ func (store *VolumeStore) getDataMapsFromVolumes(volumeNames []string) (map[stri
 }
 
 // parseTarToMap takes a TAR archive Reader and converts it into a map where each key is a file name and
-// the corresponding value is the file's content. This function iterates through each entry in the TAR archive,
-// extracts the file contents, and populates the map.
+// the corresponding value is the file's content. Optionally decrypts the content if an encryption key is provided.
 //
 // Parameters:
 // - content: An io.Reader representing the TAR content.
+// - encryptionKey: An optional byte slice used for decrypting the content.
 //
 // Returns:
-// - A map representing the extracted files and their contents, or an error if the operation fails.
+// - A map representing the extracted and possibly decrypted files and their contents.
+// - An error if the operation fails.
+//
+// Implementation Details:
+// - Iterates through each entry in the TAR archive and extracts the file contents.
+// - If an encryption key is provided, decrypts the file contents before adding to the map.
 func parseTarToMap(content io.Reader, encryptionKey []byte) (map[string]string, error) {
 	dataMap := make(map[string]string)
 	tr := tar.NewReader(content)

--- a/internal/adapter/store/volume/filters.go
+++ b/internal/adapter/store/volume/filters.go
@@ -13,8 +13,8 @@ func configMapListFilter(namespace string) filters.Args {
 	return filter
 }
 
-func secretListFilter(namespace string) filters.Args {
+func secretListFilter(namespace, secretKind string) filters.Args {
 	filter := adapterfilters.ByNamespace(namespace)
-	filter.Add("label", fmt.Sprintf("%s=%s", ResourceTypeLabelKey, SecretResourceType))
+	filter.Add("label", fmt.Sprintf("%s=%s", ResourceTypeLabelKey, secretKind))
 	return filter
 }

--- a/internal/adapter/store/volume/store.go
+++ b/internal/adapter/store/volume/store.go
@@ -110,6 +110,17 @@ func NewVolumeStore(logger *zap.SugaredLogger, opts VolumeStoreOptions) (*Volume
 	}, nil
 }
 
+// GenerateOrRetrieveEncryptionKey generates a new encryption key or retrieves an existing one from a specified folder.
+// It first checks if an encryption key file already exists in the given folder. If so, it reads the key from the file.
+// Otherwise, it generates a new 32-byte encryption key, saves it to a file in the specified folder, and then returns it.
+//
+// Parameters:
+// - logger: A pointer to a zap.SugaredLogger for logging informational messages.
+// - encryptionKeyFolder: The folder where the encryption key file should be stored or retrieved from.
+//
+// Returns:
+// - A byte slice containing the encryption key.
+// - An error if any operation (key generation, file read/write, etc.) fails.
 func GenerateOrRetrieveEncryptionKey(logger *zap.SugaredLogger, encryptionKeyFolder string) ([]byte, error) {
 	encryptionKeyPath := filepath.Join(encryptionKeyFolder, EncryptionKeyFileName)
 
@@ -131,13 +142,11 @@ func GenerateOrRetrieveEncryptionKey(logger *zap.SugaredLogger, encryptionKeyFol
 
 	logger.Infof("Encryption key file does not exist. Generating a new encryption key and storing it in file: %s", encryptionKeyPath)
 
-	// Generate a new encryption key
 	key := make([]byte, 32)
 	if _, err := rand.Read(key); err != nil {
 		return nil, fmt.Errorf("failed to generate encryption key: %w", err)
 	}
 
-	// Write the new key to disk
 	err = filesystem.CreateFileWithDirectories(encryptionKeyPath, key)
 	if err != nil {
 		return nil, fmt.Errorf("failed to write encryption key to disk: %w", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,6 +67,11 @@ type Config struct {
 	// the default value is set to disk.
 	StoreBackend string `env:"K2D_STORE_BACKEND,default=disk"`
 
+	// StoreRegistryBackend represents the backend used to store registries secrets.
+	// If not provided through an environment variable named K2D_STORE_REGISTRY_BACKEND,
+	// the default value is set to memory.
+	StoreRegistryBackend string `env:"K2D_STORE_REGISTRY_BACKEND,default=memory"`
+
 	// StoreVolumeCopyImageName represents the name of the container image used to copy and read from volumes
 	// when using the volume store for secrets and configmaps.
 	// If not provided through an environment variable named K2D_STORE_VOLUME_COPY_IMAGE_NAME,

--- a/pkg/crypto/encrypt.go
+++ b/pkg/crypto/encrypt.go
@@ -1,0 +1,51 @@
+package crypto
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"io"
+)
+
+// Encrypt encrypts the data using AES-GCM and returns the encrypted data.
+func Encrypt(plainData []byte, key []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	_, err = io.ReadFull(rand.Reader, nonce)
+	if err != nil {
+		return nil, err
+	}
+
+	ciphertext := gcm.Seal(nonce, nonce, plainData, nil)
+	return ciphertext, nil
+}
+
+// Decrypt decrypts data encrypted by AES-GCM and returns the decrypted data.
+func Decrypt(ciphertext []byte, key []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	nonce, ciphertext := ciphertext[:gcm.NonceSize()], ciphertext[gcm.NonceSize():]
+	plainData, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return plainData, nil
+}


### PR DESCRIPTION
This PR implements support for storing Docker registry secrets via an encrypted volume store.

When k2d is started with the `K2D_STORE_REGISTRY_BACKEND=volume` it will generate or retrieve the content of an encryption key under /var/lib/k2d/volume-encryption.key and use it to encrypt Docker registry secrets at rest.

When this environment variable is not specified, k2d will use the previously introduced memory store for registry secrets (see #17)

These secrets are then decrypted when needed (e.g. to pull an image from a private registry or when inspecting them).

Related to #17  