### PR TITLE
fix: fix an issue when mounting configmaps and secrets

### DIFF
--- a/internal/adapter/service.go
+++ b/internal/adapter/service.go
@@ -20,7 +20,7 @@ import (
 func (adapter *KubeDockerAdapter) DeleteService(ctx context.Context, serviceName, namespace string) error {
 	container, err := adapter.getContainerFromServiceName(ctx, serviceName, namespace)
 	if err != nil {
-		adapter.logger.Warnf("unable to get container from service name: %s", err)
+		adapter.logger.Warnf("unable to get container from service name %s: %s", serviceName, err)
 		return nil
 	}
 


### PR DESCRIPTION
This PR brings a fix to support mounting ConfigMap and Secret that have one or more values inside containers using both the disk and volume backend stores.

Related to #28 