### PR TITLE
feat: introduce naming package

### DIFF
--- a/internal/adapter/converter/pod.go
+++ b/internal/adapter/converter/pod.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/go-connections/nat"
+	"github.com/portainer/k2d/internal/adapter/naming"
 	k2dtypes "github.com/portainer/k2d/internal/adapter/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/apis/core"
@@ -484,9 +485,8 @@ func (converter *DockerAPIConverter) handleVolumeSource(namespace string, hostCo
 		bind := fmt.Sprintf("%s:%s", volume.HostPath.Path, volumeMount.MountPath)
 		hostConfig.Binds = append(hostConfig.Binds, bind)
 	} else if volume.VolumeSource.PersistentVolumeClaim != nil {
-		// TODO: Replace the fmt.Sprintf("k2d-pv-%s-%s", namespace, volume.VolumeSource.PersistentVolumeClaim.ClaimName)
-		// part with the buildPersistentVolumeName function.
-		bind := fmt.Sprintf("%s:%s", fmt.Sprintf("k2d-pv-%s-%s", namespace, volume.VolumeSource.PersistentVolumeClaim.ClaimName), volumeMount.MountPath)
+		volumeName := naming.BuildPersistentVolumeName(volume.VolumeSource.PersistentVolumeClaim.ClaimName, namespace)
+		bind := fmt.Sprintf("%s:%s", volumeName, volumeMount.MountPath)
 		hostConfig.Binds = append(hostConfig.Binds, bind)
 	}
 	return nil

--- a/internal/adapter/converter/volume.go
+++ b/internal/adapter/converter/volume.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types/volume"
+	"github.com/portainer/k2d/internal/adapter/naming"
 	k2dtypes "github.com/portainer/k2d/internal/adapter/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/apis/core"
@@ -79,9 +80,7 @@ func (converter *DockerAPIConverter) UpdateVolumeToPersistentVolumeClaim(persist
 
 	persistentVolumeClaim.Spec = core.PersistentVolumeClaimSpec{
 		StorageClassName: &storageClassName,
-		// TODO: Replace the fmt.Sprintf("k2d-pv-%s-%s", namespace, volume.VolumeSource.PersistentVolumeClaim.ClaimName)
-		// part with the buildPersistentVolumeName function.
-		VolumeName: fmt.Sprintf("k2d-pv-%s-%s", volume.Labels[k2dtypes.NamespaceLabelKey], volume.Labels[k2dtypes.PersistentVolumeClaimLabelKey]),
+		VolumeName:       naming.BuildPersistentVolumeName(volume.Labels[k2dtypes.PersistentVolumeClaimLabelKey], volume.Labels[k2dtypes.NamespaceLabelKey]),
 		AccessModes: []core.PersistentVolumeAccessMode{
 			core.ReadWriteOnce,
 		},

--- a/internal/adapter/namespace.go
+++ b/internal/adapter/namespace.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/docker/errdefs"
 	adaptererr "github.com/portainer/k2d/internal/adapter/errors"
 	"github.com/portainer/k2d/internal/adapter/filters"
+	"github.com/portainer/k2d/internal/adapter/naming"
 	k2dtypes "github.com/portainer/k2d/internal/adapter/types"
 	"github.com/portainer/k2d/internal/k8s"
 	corev1 "k8s.io/api/core/v1"
@@ -19,7 +20,7 @@ import (
 )
 
 func (adapter *KubeDockerAdapter) CreateNetworkFromNamespace(ctx context.Context, namespace *corev1.Namespace) error {
-	networkName := buildNetworkName(namespace.Name)
+	networkName := naming.BuildNetworkName(namespace.Name)
 
 	network, err := adapter.getNetwork(ctx, networkName)
 	if err != nil && !errors.Is(err, adaptererr.ErrResourceNotFound) {
@@ -77,7 +78,7 @@ func (adapter *KubeDockerAdapter) DeleteNamespace(ctx context.Context, namespace
 	// before we try to delete the network
 	time.Sleep(3 * time.Second)
 
-	networkName := buildNetworkName(namespaceName)
+	networkName := naming.BuildNetworkName(namespaceName)
 	err = adapter.cli.NetworkRemove(ctx, networkName)
 	if err != nil {
 		return fmt.Errorf("unable to delete network %s: %w", networkName, err)
@@ -88,7 +89,7 @@ func (adapter *KubeDockerAdapter) DeleteNamespace(ctx context.Context, namespace
 
 func (adapter *KubeDockerAdapter) GetNamespace(ctx context.Context, namespaceName string) (*corev1.Namespace, error) {
 
-	networkName := buildNetworkName(namespaceName)
+	networkName := naming.BuildNetworkName(namespaceName)
 
 	network, err := adapter.getNetwork(ctx, networkName)
 	if err != nil {

--- a/internal/adapter/naming/naming.go
+++ b/internal/adapter/naming/naming.go
@@ -1,4 +1,4 @@
-package adapter
+package naming
 
 import (
 	"fmt"
@@ -7,19 +7,19 @@ import (
 
 // Each container is named using the following format:
 // [namespace]-[container-name]
-func buildContainerName(containerName, namespace string) string {
+func BuildContainerName(containerName, namespace string) string {
 	containerName = strings.TrimPrefix(containerName, "/")
 	return fmt.Sprintf("%s-%s", namespace, containerName)
 }
 
 // Each network is named using the following format:
 // k2d-[namespace]
-func buildNetworkName(namespace string) string {
+func BuildNetworkName(namespace string) string {
 	return fmt.Sprintf("k2d-%s", namespace)
 }
 
 // Each persistentVolume is named using the following format:
 // k2d-pv-[namespace]-[volume-name]
-func buildPersistentVolumeName(volumeName string, namespace string) string {
+func BuildPersistentVolumeName(volumeName string, namespace string) string {
 	return fmt.Sprintf("k2d-pv-%s-%s", namespace, volumeName)
 }

--- a/internal/adapter/pod.go
+++ b/internal/adapter/pod.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/portainer/k2d/internal/adapter/errors"
 	"github.com/portainer/k2d/internal/adapter/filters"
+	"github.com/portainer/k2d/internal/adapter/naming"
 	k2dtypes "github.com/portainer/k2d/internal/adapter/types"
 	"github.com/portainer/k2d/internal/k8s"
 	corev1 "k8s.io/api/core/v1"
@@ -57,7 +58,7 @@ func (adapter *KubeDockerAdapter) GetPod(ctx context.Context, podName string, na
 
 	var container *types.Container
 
-	containerName := buildContainerName(podName, namespace)
+	containerName := naming.BuildContainerName(podName, namespace)
 	for _, cntr := range containers {
 		if cntr.Names[0] == "/"+containerName {
 			container = &cntr
@@ -91,7 +92,7 @@ func (adapter *KubeDockerAdapter) GetPod(ctx context.Context, podName string, na
 }
 
 func (adapter *KubeDockerAdapter) GetPodLogs(ctx context.Context, namespace string, podName string, opts PodLogOptions) (io.ReadCloser, error) {
-	containerName := buildContainerName(podName, namespace)
+	containerName := naming.BuildContainerName(podName, namespace)
 	container, err := adapter.cli.ContainerInspect(ctx, containerName)
 	if err != nil {
 		return nil, fmt.Errorf("unable to inspect container: %w", err)

--- a/internal/adapter/service.go
+++ b/internal/adapter/service.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/docker/api/types"
 	adaptererr "github.com/portainer/k2d/internal/adapter/errors"
 	"github.com/portainer/k2d/internal/adapter/filters"
+	"github.com/portainer/k2d/internal/adapter/naming"
 	k2dtypes "github.com/portainer/k2d/internal/adapter/types"
 	"github.com/portainer/k2d/internal/k8s"
 	"github.com/portainer/k2d/internal/logging"
@@ -37,7 +38,7 @@ func (adapter *KubeDockerAdapter) DeleteService(ctx context.Context, serviceName
 	delete(cfg.ContainerConfig.Labels, k2dtypes.ServiceNameLabelKey)
 	delete(cfg.ContainerConfig.Labels, k2dtypes.ServiceLastAppliedConfigLabelKey)
 
-	networkName := buildNetworkName(namespace)
+	networkName := naming.BuildNetworkName(namespace)
 	cfg.NetworkConfig.EndpointsConfig[networkName].Aliases = []string{}
 
 	return adapter.reCreateContainerWithNewConfiguration(ctx, container.ID, cfg)
@@ -119,7 +120,7 @@ func (adapter *KubeDockerAdapter) CreateContainerFromService(ctx context.Context
 		return fmt.Errorf("unable to convert service spec into container configuration: %w", err)
 	}
 
-	networkName := buildNetworkName(service.Namespace)
+	networkName := naming.BuildNetworkName(service.Namespace)
 	cfg.NetworkConfig.EndpointsConfig[networkName].Aliases = []string{
 		service.Name,
 		fmt.Sprintf("%s.%s", service.Name, service.Namespace),

--- a/internal/adapter/store/volume/naming.go
+++ b/internal/adapter/store/volume/naming.go
@@ -5,24 +5,34 @@ import (
 	"strings"
 )
 
+const (
+	// ConfigMapVolumePrefix is the prefix used to name volumes associated to ConfigMap resources
+	// A prefix is used to avoid clash with Secret volumes
+	ConfigMapVolumePrefix = "k2d-configmap-"
+
+	// SecretVolumePrefix is the prefix used to name volumes associated to Secret resources
+	// A prefix is used to avoid clash with ConfigMap volumes
+	SecretVolumePrefix = "k2d-secret-"
+)
+
 // Each configmap is stored as a Docker volume using the following naming convention:
-// configmap-[namespace]-[configmap-name]
+// k2d-configmap-[namespace]-[configmap-name]
 func buildConfigMapVolumeName(configMapName, namespace string) string {
 	return fmt.Sprintf("%s%s-%s", ConfigMapVolumePrefix, namespace, configMapName)
 }
 
 // Each secret is stored as a Docker volume using the following naming convention:
-// secret-[namespace]-[secret-name]
+// k2d-secret-[namespace]-[secret-name]
 func buildSecretVolumeName(configMapName, namespace string) string {
 	return fmt.Sprintf("%s%s-%s", SecretVolumePrefix, namespace, configMapName)
 }
 
-// Returns [configmap-name] from configmap-[namespace]-[configmap-name]
+// Returns [configmap-name] from k2d-configmap-[namespace]-[configmap-name]
 func getConfigMapNameFromVolumeName(volumeName, namespace string) string {
 	return strings.TrimPrefix(volumeName, fmt.Sprintf("%s%s-", ConfigMapVolumePrefix, namespace))
 }
 
-// Returns [secret-name] from secret-[namespace]-[secret-name]
+// Returns [secret-name] from k2d-secret-[namespace]-[secret-name]
 func getSecretNameFromVolumeName(volumeName, namespace string) string {
 	return strings.TrimPrefix(volumeName, fmt.Sprintf("%s%s-", SecretVolumePrefix, namespace))
 }

--- a/internal/adapter/store/volume/store.go
+++ b/internal/adapter/store/volume/store.go
@@ -28,10 +28,6 @@ const (
 )
 
 const (
-	// ConfigMapVolumePrefix is the prefix used to name volumes associated to ConfigMap resources
-	// A prefix is used to avoid clash with Secret volumes
-	ConfigMapVolumePrefix = "configmap-"
-
 	// ConfigMapResourceType is the label value used to identify a volume that is associated to a ConfigMap resource
 	// It is stored on a volume as a label and used to filter volumes when listing volumes associated to ConfigMaps
 	ConfigMapResourceType = "configmap"
@@ -40,10 +36,6 @@ const (
 	// used to store a Docker registry credentials.
 	// It is stored on a volume as a label and used to filter volumes when listing volumes associated to Secrets
 	RegistrySecretResourceType = "registrysecret"
-
-	// SecretVolumePrefix is the prefix used to name volumes associated to Secret resources
-	// A prefix is used to avoid clash with ConfigMap volumes
-	SecretVolumePrefix = "secret-"
 
 	// SecretResourceType is the label value used to identify a volume that is associated to a Secret resource
 	// It is stored on a volume as a label and used to filter volumes when listing volumes associated to Secrets


### PR DESCRIPTION
This PR introduces a naming package that allows to reuse the naming functions across different places in the codebase.

It also changes the name of volumes created for Secret and ConfigMap when using the volume store backend to add the "k2d" prefix, this is to match the naming convention across all resources.