### PR TITLE
fix: fix an issue preventing the edge agent from starting

### DIFF
--- a/internal/adapter/container_utils.go
+++ b/internal/adapter/container_utils.go
@@ -456,10 +456,6 @@ func (adapter *KubeDockerAdapter) DeployPortainerEdgeAgent(ctx context.Context, 
 	}
 
 	hostConfig := &container.HostConfig{
-		// Binds: []string{
-		// 	fmt.Sprintf("%s:%s", adapter.k2dServerConfiguration.CaPath, "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"),
-		// 	fmt.Sprintf("%s:%s", adapter.k2dServerConfiguration.TokenPath, "/var/run/secrets/kubernetes.io/serviceaccount/token"),
-		// },
 		ExtraHosts: []string{
 			fmt.Sprintf("kubernetes.default.svc:%s", adapter.k2dServerConfiguration.ServerIpAddr),
 		},

--- a/internal/adapter/container_utils.go
+++ b/internal/adapter/container_utils.go
@@ -456,16 +456,20 @@ func (adapter *KubeDockerAdapter) DeployPortainerEdgeAgent(ctx context.Context, 
 	}
 
 	hostConfig := &container.HostConfig{
-		Binds: []string{
-			fmt.Sprintf("%s:%s", adapter.k2dServerConfiguration.CaPath, "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"),
-			fmt.Sprintf("%s:%s", adapter.k2dServerConfiguration.TokenPath, "/var/run/secrets/kubernetes.io/serviceaccount/token"),
-		},
+		// Binds: []string{
+		// 	fmt.Sprintf("%s:%s", adapter.k2dServerConfiguration.CaPath, "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"),
+		// 	fmt.Sprintf("%s:%s", adapter.k2dServerConfiguration.TokenPath, "/var/run/secrets/kubernetes.io/serviceaccount/token"),
+		// },
 		ExtraHosts: []string{
 			fmt.Sprintf("kubernetes.default.svc:%s", adapter.k2dServerConfiguration.ServerIpAddr),
 		},
 		RestartPolicy: container.RestartPolicy{
 			Name: "always",
 		},
+	}
+
+	if err := adapter.converter.SetServiceAccountTokenAndCACert(hostConfig); err != nil {
+		return fmt.Errorf("unable to set service account token and CA cert: %w", err)
 	}
 
 	networkName := naming.BuildNetworkName(k2dtypes.K2DNamespaceName)

--- a/internal/adapter/converter/pod.go
+++ b/internal/adapter/converter/pod.go
@@ -127,7 +127,7 @@ func (converter *DockerAPIConverter) ConvertPodSpecToContainerConfiguration(spec
 		},
 	}
 
-	if err := converter.setServiceAccountTokenAndCACert(hostConfig); err != nil {
+	if err := converter.SetServiceAccountTokenAndCACert(hostConfig); err != nil {
 		return ContainerConfiguration{}, err
 	}
 
@@ -189,7 +189,7 @@ func (converter *DockerAPIConverter) setResourceRequirements(hostConfig *contain
 	hostConfig.Resources = resourceRequirements
 }
 
-// setServiceAccountTokenAndCACert configures the Docker container to have access to the service account token
+// SetServiceAccountTokenAndCACert configures the Docker container to have access to the service account token
 // and CA certificate stored in a Kubernetes Secret. The function performs the following steps:
 //  1. Fetches the service account Secret from Kubernetes using the provided secretStore.
 //  2. Obtains the filesystem bind mappings for the Secret using the secretStore's GetSecretBinds method.
@@ -201,7 +201,7 @@ func (converter *DockerAPIConverter) setResourceRequirements(hostConfig *contain
 //     account token and CA certificate binds.
 //
 // It returns an error if any occurred fetching the Secret or obtaining the bind mappings fails.
-func (converter *DockerAPIConverter) setServiceAccountTokenAndCACert(hostConfig *container.HostConfig) error {
+func (converter *DockerAPIConverter) SetServiceAccountTokenAndCACert(hostConfig *container.HostConfig) error {
 	secret, err := converter.secretStore.GetSecret(k2dtypes.K2dServiceAccountSecretName, k2dtypes.K2DNamespaceName)
 	if err != nil {
 		return fmt.Errorf("unable to get secret %s: %w", k2dtypes.K2dServiceAccountSecretName, err)


### PR DESCRIPTION
This PR fixes an issue preventing the Portainer async Edge agent from starting when using the `PORTAINER_EDGE_KEY `in conjunction with `K2D_STORE_BACKEND=volume`.

Related to #28 