### PR TITLE
refactor: change the default reclaim policy to retain

### DIFF
--- a/internal/adapter/converter/persistentvolume.go
+++ b/internal/adapter/converter/persistentvolume.go
@@ -37,7 +37,7 @@ func (converter *DockerAPIConverter) ConvertVolumeToPersistentVolume(volume volu
 			AccessModes: []core.PersistentVolumeAccessMode{
 				core.ReadWriteOnce,
 			},
-			PersistentVolumeReclaimPolicy: core.PersistentVolumeReclaimDelete,
+			PersistentVolumeReclaimPolicy: core.PersistentVolumeReclaimRetain,
 			PersistentVolumeSource: core.PersistentVolumeSource{
 				HostPath: &core.HostPathVolumeSource{
 					Path: volume.Mountpoint,

--- a/internal/adapter/converter/persistentvolume.go
+++ b/internal/adapter/converter/persistentvolume.go
@@ -25,6 +25,7 @@ func (converter *DockerAPIConverter) ConvertVolumeToPersistentVolume(volume volu
 
 	configMap, err := converter.configMapStore.GetConfigMap(volume.Labels[k2dtypes.PersistentVolumeClaimLabelKey], volume.Labels[k2dtypes.NamespaceLabelKey])
 	if err != nil {
+		// how to make this logged as an info
 		fmt.Printf("unable to retrieve config map for volume %s: %s\n. Setting the phase to released and no claim reference", volume.Name, err)
 	}
 

--- a/internal/adapter/converter/persistentvolumeclaim.go
+++ b/internal/adapter/converter/persistentvolumeclaim.go
@@ -4,17 +4,17 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/docker/docker/api/types/volume"
 	"github.com/portainer/k2d/internal/adapter/naming"
 	k2dtypes "github.com/portainer/k2d/internal/adapter/types"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/apis/core"
 )
 
-func (converter *DockerAPIConverter) UpdateVolumeToPersistentVolumeClaim(persistentVolumeClaim *core.PersistentVolumeClaim, volume volume.Volume) error {
-	creationDate, err := time.Parse(time.RFC3339, volume.CreatedAt)
+func (converter *DockerAPIConverter) UpdateConfigMapToPersistentVolumeClaim(persistentVolumeClaim *core.PersistentVolumeClaim, configMap *corev1.ConfigMap) error {
+	creationDate, err := time.Parse(time.RFC3339, configMap.Labels["store.k2d.io/filesystem/creation-timestamp"])
 	if err != nil {
-		return fmt.Errorf("unable to parse volume creation date: %w", err)
+		return fmt.Errorf("unable to parse persistent volume claim creation date: %w", err)
 	}
 
 	storageClassName := "local"
@@ -25,19 +25,19 @@ func (converter *DockerAPIConverter) UpdateVolumeToPersistentVolumeClaim(persist
 	}
 
 	persistentVolumeClaim.ObjectMeta = metav1.ObjectMeta{
-		Name:      volume.Labels[k2dtypes.PersistentVolumeClaimLabelKey],
-		Namespace: volume.Labels[k2dtypes.NamespaceLabelKey],
+		Name:      configMap.Labels[k2dtypes.PersistentVolumeClaimLabelKey],
+		Namespace: configMap.Labels[k2dtypes.NamespaceLabelKey],
 		CreationTimestamp: metav1.Time{
 			Time: creationDate,
 		},
 		Annotations: map[string]string{
-			"kubectl.kubernetes.io/last-applied-configuration": volume.Labels[k2dtypes.PersistentVolumeClaimLastAppliedConfigLabelKey],
+			"kubectl.kubernetes.io/last-applied-configuration": configMap.Labels[k2dtypes.PersistentVolumeClaimLastAppliedConfigLabelKey],
 		},
 	}
 
 	persistentVolumeClaim.Spec = core.PersistentVolumeClaimSpec{
 		StorageClassName: &storageClassName,
-		VolumeName:       naming.BuildPersistentVolumeName(volume.Labels[k2dtypes.PersistentVolumeClaimLabelKey], volume.Labels[k2dtypes.NamespaceLabelKey]),
+		VolumeName:       naming.BuildPersistentVolumeName(configMap.Labels[k2dtypes.PersistentVolumeClaimLabelKey], configMap.Labels[k2dtypes.NamespaceLabelKey]),
 		AccessModes: []core.PersistentVolumeAccessMode{
 			core.ReadWriteOnce,
 		},

--- a/internal/adapter/filters/filters.go
+++ b/internal/adapter/filters/filters.go
@@ -140,3 +140,19 @@ func ByService(namespace, serviceName string) filters.Args {
 	filter.Add("label", fmt.Sprintf("%s=%s", types.NamespaceLabelKey, namespace))
 	return filter
 }
+
+// AllPersistentVolumes creates a Docker filter argument to list persistent volumes if the PersistentVolumeLabelKey exists.
+//
+// Parameters:
+//   - None.
+//
+// Returns:
+// - filters.Args: A Docker filter object to be used in Docker API calls to filter persistent volumes.
+//
+// Usage Example:
+//
+//	filter := AllPersistentVolumes()
+//	// Now 'filter' can be used in Docker API calls to filter persistent volumes.
+func AllPersistentVolumes() filters.Args {
+	return filters.NewArgs(filters.Arg("label", types.PersistentVolumeLabelKey))
+}

--- a/internal/adapter/namespace.go
+++ b/internal/adapter/namespace.go
@@ -71,7 +71,9 @@ func (adapter *KubeDockerAdapter) DeleteNamespace(ctx context.Context, namespace
 	}
 
 	for _, container := range containers {
-		adapter.DeleteContainer(ctx, container.Names[0], namespaceName)
+		// the container name has to come from the label as the container name itself was already built
+		// with the function naming.BuildContainerName
+		adapter.DeleteContainer(ctx, container.Labels[k2dtypes.WorkloadNameLabelKey], namespaceName)
 	}
 
 	// This is just to make sure that the containers have been properly deleted

--- a/internal/adapter/naming/naming.go
+++ b/internal/adapter/naming/naming.go
@@ -23,9 +23,3 @@ func BuildNetworkName(namespace string) string {
 func BuildPersistentVolumeName(volumeName string, namespace string) string {
 	return fmt.Sprintf("k2d-pv-%s-%s", namespace, volumeName)
 }
-
-// Each persistentVolumeClaim is named using the following format:
-// k2d-pvc-[namespace]-[volume-name]
-func BuildPersistentVolumeClaimName(volumeName string, namespace string) string {
-	return fmt.Sprintf("k2d-pvc-%s-%s", namespace, volumeName)
-}

--- a/internal/adapter/naming/naming.go
+++ b/internal/adapter/naming/naming.go
@@ -23,3 +23,9 @@ func BuildNetworkName(namespace string) string {
 func BuildPersistentVolumeName(volumeName string, namespace string) string {
 	return fmt.Sprintf("k2d-pv-%s-%s", namespace, volumeName)
 }
+
+// Each persistentVolumeClaim is named using the following format:
+// k2d-pvc-[namespace]-[volume-name]
+func BuildPersistentVolumeClaimName(volumeName string, namespace string) string {
+	return fmt.Sprintf("k2d-pvc-%s-%s", namespace, volumeName)
+}

--- a/internal/adapter/persistentvolume.go
+++ b/internal/adapter/persistentvolume.go
@@ -15,6 +15,15 @@ import (
 	"k8s.io/kubernetes/pkg/apis/core"
 )
 
+func (adapter *KubeDockerAdapter) DeletePersistentVolume(ctx context.Context, persistentVolumeName string) error {
+	err := adapter.cli.VolumeRemove(ctx, persistentVolumeName, true)
+	if err != nil {
+		return fmt.Errorf("unable to remove Docker volume: %w", err)
+	}
+
+	return nil
+}
+
 func (adapter *KubeDockerAdapter) GetPersistentVolume(ctx context.Context, persistentVolumeName string) (*corev1.PersistentVolume, error) {
 	volume, err := adapter.cli.VolumeInspect(ctx, persistentVolumeName)
 	if err != nil {
@@ -56,7 +65,7 @@ func (adapter *KubeDockerAdapter) ListPersistentVolumes(ctx context.Context) (co
 func (adapter *KubeDockerAdapter) GetPersistentVolumeTable(ctx context.Context) (*metav1.Table, error) {
 	persistentVolumeList, err := adapter.listPersistentVolumes(ctx)
 	if err != nil {
-		return &metav1.Table{}, fmt.Errorf("unable to list nodes: %w", err)
+		return &metav1.Table{}, fmt.Errorf("unable to list persistent volumes: %w", err)
 	}
 
 	return k8s.GenerateTable(&persistentVolumeList)

--- a/internal/adapter/persistentvolume.go
+++ b/internal/adapter/persistentvolume.go
@@ -4,11 +4,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/errdefs"
 	adaptererr "github.com/portainer/k2d/internal/adapter/errors"
-	k2dtypes "github.com/portainer/k2d/internal/adapter/types"
+	"github.com/portainer/k2d/internal/adapter/filters"
 	"github.com/portainer/k2d/internal/k8s"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -72,10 +71,9 @@ func (adapter *KubeDockerAdapter) GetPersistentVolumeTable(ctx context.Context) 
 }
 
 func (adapter *KubeDockerAdapter) listPersistentVolumes(ctx context.Context) (core.PersistentVolumeList, error) {
-	labelFilter := filters.NewArgs()
-	labelFilter.Add("label", k2dtypes.PersistentVolumeLabelKey)
+	filter := filters.AllPersistentVolumes()
 
-	volumeList, err := adapter.cli.VolumeList(ctx, volume.ListOptions{Filters: labelFilter})
+	volumeList, err := adapter.cli.VolumeList(ctx, volume.ListOptions{Filters: filter})
 	if err != nil {
 		return core.PersistentVolumeList{}, fmt.Errorf("unable to list volumes to return the output values from a Docker volume: %w", err)
 	}

--- a/internal/adapter/storageclass.go
+++ b/internal/adapter/storageclass.go
@@ -6,8 +6,10 @@ import (
 
 	adaptererr "github.com/portainer/k2d/internal/adapter/errors"
 	"github.com/portainer/k2d/internal/k8s"
+	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/storage"
 )
 
@@ -15,6 +17,8 @@ func (adapter *KubeDockerAdapter) GetStorageClass(ctx context.Context, storageCl
 	if storageClassName != "local" {
 		return nil, adaptererr.ErrResourceNotFound
 	}
+
+	reclaimPolicy := corev1.PersistentVolumeReclaimPolicy("Retain")
 
 	return &storagev1.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{
@@ -24,7 +28,8 @@ func (adapter *KubeDockerAdapter) GetStorageClass(ctx context.Context, storageCl
 			Kind:       "StorageClass",
 			APIVersion: "storage.k8s.io/v1",
 		},
-		Provisioner: "local",
+		Provisioner:   "local",
+		ReclaimPolicy: &reclaimPolicy,
 	}, nil
 }
 
@@ -48,6 +53,8 @@ func (adapter *KubeDockerAdapter) GetStorageClassTable(ctx context.Context) (*me
 
 func (adapter *KubeDockerAdapter) listStorageClasses(ctx context.Context) (storage.StorageClassList, error) {
 	storageClasses := []storage.StorageClass{}
+
+	reclaimPolicy := core.PersistentVolumeReclaimPolicy("Retain")
 	storageClasses = append(storageClasses, storage.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "local",
@@ -56,7 +63,8 @@ func (adapter *KubeDockerAdapter) listStorageClasses(ctx context.Context) (stora
 			Kind:       "StorageClass",
 			APIVersion: "storage.k8s.io/v1",
 		},
-		Provisioner: "local",
+		Provisioner:   "local",
+		ReclaimPolicy: &reclaimPolicy,
 	})
 
 	return storage.StorageClassList{

--- a/internal/api/core/v1/persistentvolumeclaims/delete.go
+++ b/internal/api/core/v1/persistentvolumeclaims/delete.go
@@ -15,7 +15,7 @@ func (svc PersistentVolumeClaimService) DeletePersistentVolumeClaim(r *restful.R
 
 	err := svc.adapter.DeletePersistentVolumeClaim(r.Request.Context(), persistentVolumeClaimName, namespace)
 	if err != nil {
-		utils.HttpError(r, w, http.StatusInternalServerError, fmt.Errorf("unable to delete network: %w", err))
+		utils.HttpError(r, w, http.StatusInternalServerError, fmt.Errorf("unable to delete persistent volume claim: %w", err))
 		return
 	}
 

--- a/internal/api/core/v1/persistentvolumes/delete.go
+++ b/internal/api/core/v1/persistentvolumes/delete.go
@@ -1,0 +1,29 @@
+package persistentvolumes
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/emicklei/go-restful/v3"
+	"github.com/portainer/k2d/internal/api/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (svc PersistentVolumeService) DeletePersistentVolume(r *restful.Request, w *restful.Response) {
+	persistentVolumeName := r.PathParameter("name")
+
+	err := svc.adapter.DeletePersistentVolume(r.Request.Context(), persistentVolumeName)
+	if err != nil {
+		utils.HttpError(r, w, http.StatusInternalServerError, fmt.Errorf("unable to delete persistent volume: %w", err))
+		return
+	}
+
+	w.WriteAsJson(metav1.Status{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Status",
+			APIVersion: "v1",
+		},
+		Status: "Success",
+		Code:   http.StatusOK,
+	})
+}

--- a/internal/api/core/v1/persistentvolumes/persistentvolumes.go
+++ b/internal/api/core/v1/persistentvolumes/persistentvolumes.go
@@ -24,6 +24,6 @@ func (svc PersistentVolumeService) RegisterPersistentVolumeAPI(ws *restful.WebSe
 		Param(ws.PathParameter("name", "name of the persistentvolume").DataType("string")))
 
 	ws.Route(ws.DELETE("/v1/persistentvolumes/{name}").
-		To(svc.GetPersistentVolume).
-		Param(ws.PathParameter("name", "name of the persistentvolumes").DataType("string")))
+		To(svc.DeletePersistentVolume).
+		Param(ws.PathParameter("name", "name of the persistentvolume").DataType("string")))
 }

--- a/internal/api/core/v1/persistentvolumes/persistentvolumes.go
+++ b/internal/api/core/v1/persistentvolumes/persistentvolumes.go
@@ -22,4 +22,8 @@ func (svc PersistentVolumeService) RegisterPersistentVolumeAPI(ws *restful.WebSe
 	ws.Route(ws.GET("/v1/persistentvolumes/{name}").
 		To(svc.GetPersistentVolume).
 		Param(ws.PathParameter("name", "name of the persistentvolume").DataType("string")))
+
+	ws.Route(ws.DELETE("/v1/persistentvolumes/{name}").
+		To(svc.GetPersistentVolume).
+		Param(ws.PathParameter("name", "name of the persistentvolumes").DataType("string")))
 }

--- a/pkg/filesystem/file.go
+++ b/pkg/filesystem/file.go
@@ -122,6 +122,12 @@ func LoadMetadataFromDisk(storagePath, fileName string) (map[string]string, erro
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		line := scanner.Text()
+		// configmap may contain an empty line at the end
+		// in this case, skip it
+		if line == "" {
+			continue
+		}
+
 		parts := strings.SplitN(line, "=", 2)
 		if len(parts) != 2 {
 			return nil, fmt.Errorf("invalid data format: %s", line)


### PR DESCRIPTION
This PR changes the default reclaim policy to `retain`, changing from `delete`.

When a new PVC is deployed, it will create a PV (as a Docker Volume), the same behaviour as before. However, when the PVC is deleted, the PV remains, emulating the `retain` reclaim policy.

Also, this allows the users to specify the `volumeName` in the PVC spec.

This implementation leverages system ConfigMaps to store the data associated to PVC without having to store this information on the Docker volume itself anymore.

Related to #12 