### PR TITLE
feat: store system configmap in the k2d namespace

### DIFF
--- a/internal/adapter/configmap.go
+++ b/internal/adapter/configmap.go
@@ -3,6 +3,7 @@ package adapter
 import (
 	"fmt"
 
+	"github.com/portainer/k2d/internal/adapter/types"
 	"github.com/portainer/k2d/internal/k8s"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,8 +14,19 @@ func (adapter *KubeDockerAdapter) CreateConfigMap(configMap *corev1.ConfigMap) e
 	return adapter.configMapStore.StoreConfigMap(configMap)
 }
 
+// CreateSystemConfigMap is a wrapper around CreateConfigMap for clarity purpose. It creates a configmap in the k2d namespace.
+func (adapter *KubeDockerAdapter) CreateSystemConfigMap(configMap *corev1.ConfigMap) error {
+	configMap.Namespace = types.K2DNamespaceName
+	return adapter.configMapStore.StoreConfigMap(configMap)
+}
+
 func (adapter *KubeDockerAdapter) DeleteConfigMap(configMapName, namespace string) error {
 	return adapter.configMapStore.DeleteConfigMap(configMapName, namespace)
+}
+
+// DeleteSystemConfigMap is a wrapper around DeleteConfigMap for clarity purpose. It deletes a configmap from the k2d namespace.
+func (adapter *KubeDockerAdapter) DeleteSystemConfigMap(configMapName string) error {
+	return adapter.configMapStore.DeleteConfigMap(configMapName, types.K2DNamespaceName)
 }
 
 func (adapter *KubeDockerAdapter) GetConfigMap(configMapName, namespace string) (*corev1.ConfigMap, error) {
@@ -38,6 +50,11 @@ func (adapter *KubeDockerAdapter) GetConfigMap(configMapName, namespace string) 
 	versionedConfigMap.ObjectMeta.Annotations["kubectl.kubernetes.io/last-applied-configuration"] = ""
 
 	return &versionedConfigMap, nil
+}
+
+// GetSystemConfigMap is a wrapper around GetConfigMap for clarity purpose. It retrieves a configmap from the k2d namespace.
+func (adapter *KubeDockerAdapter) GetSystemConfigMap(configMapName string) (*corev1.ConfigMap, error) {
+	return adapter.GetConfigMap(configMapName, types.K2DNamespaceName)
 }
 
 func (adapter *KubeDockerAdapter) GetConfigMapTable(namespace string) (*metav1.Table, error) {
@@ -68,6 +85,11 @@ func (adapter *KubeDockerAdapter) ListConfigMaps(namespace string) (corev1.Confi
 	}
 
 	return versionedConfigMapList, nil
+}
+
+// ListSystemConfigMaps is a wrapper around ListConfigMaps for clarity purpose. It lists configmaps from the k2d namespace.
+func (adapter *KubeDockerAdapter) ListSystemConfigMaps() (corev1.ConfigMapList, error) {
+	return adapter.ListConfigMaps(types.K2DNamespaceName)
 }
 
 func (adapter *KubeDockerAdapter) listConfigMaps(namespace string) (core.ConfigMapList, error) {

--- a/internal/adapter/container_utils.go
+++ b/internal/adapter/container_utils.go
@@ -239,7 +239,7 @@ func (adapter *KubeDockerAdapter) createContainerFromPodSpec(ctx context.Context
 		return fmt.Errorf("unable to marshal internal pod spec: %w", err)
 	}
 	options.labels[k2dtypes.PodLastAppliedConfigLabelKey] = string(internalPodSpecData)
-	options.labels[k2dtypes.NamespaceLabelKey] = options.namespace
+	options.labels[k2dtypes.NamespaceNameLabelKey] = options.namespace
 	options.labels[k2dtypes.WorkloadNameLabelKey] = options.containerName
 	options.labels[k2dtypes.NetworkNameLabelKey] = naming.BuildNetworkName(options.namespace)
 

--- a/internal/adapter/converter/persistentvolumeclaim.go
+++ b/internal/adapter/converter/persistentvolumeclaim.go
@@ -12,6 +12,7 @@ import (
 )
 
 func (converter *DockerAPIConverter) UpdateConfigMapToPersistentVolumeClaim(persistentVolumeClaim *core.PersistentVolumeClaim, configMap *corev1.ConfigMap) error {
+	// TODO: this should be reviewed, there should be a single way to retrieve information from the store interface
 	// creation-timestamp can be obtained from a label or directly from the metadata, based on how the K2D_STORE_BACKEND is set
 	creationDate := ""
 	if configMap.Labels["store.k2d.io/filesystem/creation-timestamp"] != "" {
@@ -33,8 +34,8 @@ func (converter *DockerAPIConverter) UpdateConfigMapToPersistentVolumeClaim(pers
 	}
 
 	persistentVolumeClaim.ObjectMeta = metav1.ObjectMeta{
-		Name:      configMap.Labels[k2dtypes.PersistentVolumeClaimLabelKey],
-		Namespace: configMap.Labels[k2dtypes.NamespaceLabelKey],
+		Name:      configMap.Labels[k2dtypes.PersistentVolumeClaimNameLabelKey],
+		Namespace: configMap.Labels[k2dtypes.NamespaceNameLabelKey],
 		CreationTimestamp: metav1.Time{
 			Time: timeConvertedCreationDate,
 		},
@@ -45,7 +46,7 @@ func (converter *DockerAPIConverter) UpdateConfigMapToPersistentVolumeClaim(pers
 
 	persistentVolumeClaim.Spec = core.PersistentVolumeClaimSpec{
 		StorageClassName: &storageClassName,
-		VolumeName:       naming.BuildPersistentVolumeName(configMap.Labels[k2dtypes.PersistentVolumeClaimLabelKey], configMap.Labels[k2dtypes.NamespaceLabelKey]),
+		VolumeName:       naming.BuildPersistentVolumeName(configMap.Labels[k2dtypes.PersistentVolumeClaimNameLabelKey], configMap.Labels[k2dtypes.NamespaceNameLabelKey]),
 		AccessModes: []core.PersistentVolumeAccessMode{
 			core.ReadWriteOnce,
 		},

--- a/internal/adapter/filters/filters.go
+++ b/internal/adapter/filters/filters.go
@@ -40,7 +40,7 @@ func AllDeployments(namespace string) filters.Args {
 //	filter := AllNamespaces()
 //	// Now 'filter' can be used in Docker API calls to filter resources that are labeled with any Kubernetes namespace.
 func AllNamespaces() filters.Args {
-	return filters.NewArgs(filters.Arg("label", types.NamespaceLabelKey))
+	return filters.NewArgs(filters.Arg("label", types.NamespaceNameLabelKey))
 }
 
 // AllServices creates a Docker filter argument to target all Docker resources labeled as services within a specific Kubernetes namespace.
@@ -98,7 +98,7 @@ func ByNamespace(namespace string) filters.Args {
 	if namespace == "" {
 		return AllNamespaces()
 	}
-	return filters.NewArgs(filters.Arg("label", fmt.Sprintf("%s=%s", types.NamespaceLabelKey, namespace)))
+	return filters.NewArgs(filters.Arg("label", fmt.Sprintf("%s=%s", types.NamespaceNameLabelKey, namespace)))
 }
 
 // ByPod creates a Docker filter argument to target a specific pod within a specific Kubernetes namespace.
@@ -116,7 +116,7 @@ func ByNamespace(namespace string) filters.Args {
 //	// Now 'filter' can be used in Docker API calls to filter resources of pod 'mypod' in the 'default' Kubernetes namespace.
 func ByPod(namespace, podName string) filters.Args {
 	filter := filters.NewArgs()
-	filter.Add("label", fmt.Sprintf("%s=%s", types.NamespaceLabelKey, namespace))
+	filter.Add("label", fmt.Sprintf("%s=%s", types.NamespaceNameLabelKey, namespace))
 	filter.Add("label", fmt.Sprintf("%s=%s", types.WorkloadNameLabelKey, podName))
 	return filter
 }
@@ -137,22 +137,23 @@ func ByPod(namespace, podName string) filters.Args {
 func ByService(namespace, serviceName string) filters.Args {
 	filter := filters.NewArgs()
 	filter.Add("label", fmt.Sprintf("%s=%s", types.ServiceNameLabelKey, serviceName))
-	filter.Add("label", fmt.Sprintf("%s=%s", types.NamespaceLabelKey, namespace))
+	filter.Add("label", fmt.Sprintf("%s=%s", types.NamespaceNameLabelKey, namespace))
 	return filter
 }
 
-// AllPersistentVolumes creates a Docker filter argument to list persistent volumes if the PersistentVolumeLabelKey exists.
+// AllPersistentVolumes creates a Docker filter argument that targets resources labeled with a Kubernetes persistent volume name.
+// This function uses the types.PersistentVolumeNameLabelKey constant as the base label key to filter Docker resources.
 //
 // Parameters:
-//   - None.
+//   - None
 //
 // Returns:
-// - filters.Args: A Docker filter object to be used in Docker API calls to filter persistent volumes.
+// - filters.Args: A Docker filter object that can be used to filter Docker API calls based on the presence of the persistent volume name label.
 //
 // Usage Example:
 //
 //	filter := AllPersistentVolumes()
-//	// Now 'filter' can be used in Docker API calls to filter persistent volumes.
+//	// Now 'filter' can be used in Docker API calls to filter resources that are labeled with any Kubernetes persistent volume name.
 func AllPersistentVolumes() filters.Args {
-	return filters.NewArgs(filters.Arg("label", types.PersistentVolumeLabelKey))
+	return filters.NewArgs(filters.Arg("label", types.PersistentVolumeNameLabelKey))
 }

--- a/internal/adapter/namespace.go
+++ b/internal/adapter/namespace.go
@@ -47,7 +47,7 @@ func (adapter *KubeDockerAdapter) CreateNetworkFromNamespace(ctx context.Context
 	networkOptions := types.NetworkCreate{
 		Driver: "bridge",
 		Labels: map[string]string{
-			k2dtypes.NamespaceLabelKey:                  namespace.Name,
+			k2dtypes.NamespaceNameLabelKey:              namespace.Name,
 			k2dtypes.NamespaceLastAppliedConfigLabelKey: lastAppliedConfiguration,
 		},
 		Options: map[string]string{
@@ -166,7 +166,7 @@ func (adapter *KubeDockerAdapter) listNamespaces(ctx context.Context) (core.Name
 	namespaceList := []core.Namespace{}
 
 	for _, network := range networks {
-		namespace := network.Labels[k2dtypes.NamespaceLabelKey]
+		namespace := network.Labels[k2dtypes.NamespaceNameLabelKey]
 		namespaceList = append(namespaceList, adapter.converter.ConvertNetworkToNamespace(namespace, network))
 	}
 

--- a/internal/adapter/naming/naming.go
+++ b/internal/adapter/naming/naming.go
@@ -18,8 +18,14 @@ func BuildNetworkName(namespace string) string {
 	return fmt.Sprintf("k2d-%s", namespace)
 }
 
-// Each persistentVolume is named using the following format:
+// Each volume is named using the following format:
 // k2d-pv-[namespace]-[volume-name]
 func BuildPersistentVolumeName(volumeName string, namespace string) string {
 	return fmt.Sprintf("k2d-pv-%s-%s", namespace, volumeName)
+}
+
+// Each system configmap associated to a PVC is named using the following format:
+// pvc-[namespace]-[pvc-name]
+func BuildPVCSystemConfigMapName(persistentVolumeClaimName, namespace string) string {
+	return fmt.Sprintf("pvc-%s-%s", namespace, persistentVolumeClaimName)
 }

--- a/internal/adapter/persistentvolumeclaim.go
+++ b/internal/adapter/persistentvolumeclaim.go
@@ -184,7 +184,6 @@ func (adapter *KubeDockerAdapter) GetPersistentVolumeClaimTable(ctx context.Cont
 }
 
 func (adapter *KubeDockerAdapter) listPersistentVolumeClaims(ctx context.Context, namespaceName string) (core.PersistentVolumeClaimList, error) {
-	// configMaps, err := adapter.ListConfigMaps(namespaceName)
 	configMaps, err := adapter.ListSystemConfigMaps()
 	if err != nil {
 		return core.PersistentVolumeClaimList{}, fmt.Errorf("unable to list configmaps: %w", err)
@@ -198,11 +197,8 @@ func (adapter *KubeDockerAdapter) listPersistentVolumeClaims(ctx context.Context
 	}
 
 	for _, configMap := range configMaps.Items {
-		// persistentVolumeClaimName := configMap.Labels[k2dtypes.PersistentVolumeClaimNameLabelKey]
 		namespace := configMap.Labels[k2dtypes.NamespaceNameLabelKey]
 
-		// TODO: not sure about this condition, seems to me that it is always set
-		// if persistentVolumeClaimName != "" {
 		if namespaceName == "" || namespace == namespaceName {
 			persistentvolumeClaimLastAppliedConfigLabelKey := configMap.Labels[k2dtypes.PersistentVolumeClaimLastAppliedConfigLabelKey]
 

--- a/internal/adapter/store/volume/configmap.go
+++ b/internal/adapter/store/volume/configmap.go
@@ -163,8 +163,8 @@ func (store *VolumeStore) StoreConfigMap(configMap *corev1.ConfigMap) error {
 	volumeName := buildConfigMapVolumeName(configMap.Name, configMap.Namespace)
 
 	labels := map[string]string{
-		ResourceTypeLabelKey:    ConfigMapResourceType,
-		types.NamespaceLabelKey: configMap.Namespace,
+		ResourceTypeLabelKey:        ConfigMapResourceType,
+		types.NamespaceNameLabelKey: configMap.Namespace,
 	}
 	maputils.MergeMapsInPlace(labels, configMap.Labels)
 
@@ -187,7 +187,7 @@ func (store *VolumeStore) StoreConfigMap(configMap *corev1.ConfigMap) error {
 // createConfigMapFromVolume constructs a Kubernetes ConfigMap object from a Docker volume.
 // Returns a ConfigMap object, and an error if any occurs (e.g., if the volume's creation timestamp is not parseable).
 func createConfigMapFromVolume(volume *volume.Volume) (core.ConfigMap, error) {
-	namespace := volume.Labels[types.NamespaceLabelKey]
+	namespace := volume.Labels[types.NamespaceNameLabelKey]
 
 	configMap := core.ConfigMap{
 		TypeMeta: metav1.TypeMeta{

--- a/internal/adapter/store/volume/secret.go
+++ b/internal/adapter/store/volume/secret.go
@@ -173,9 +173,9 @@ func (s *VolumeStore) StoreSecret(secret *corev1.Secret) error {
 	volumeName := buildSecretVolumeName(secret.Name, secret.Namespace)
 
 	labels := map[string]string{
-		ResourceTypeLabelKey:    s.secretKind,
-		SecretTypeLabelKey:      string(secret.Type),
-		types.NamespaceLabelKey: secret.Namespace,
+		ResourceTypeLabelKey:        s.secretKind,
+		SecretTypeLabelKey:          string(secret.Type),
+		types.NamespaceNameLabelKey: secret.Namespace,
 	}
 	maputils.MergeMapsInPlace(labels, secret.Labels)
 
@@ -208,7 +208,7 @@ func (s *VolumeStore) StoreSecret(secret *corev1.Secret) error {
 // createSecretFromVolume constructs a Kubernetes Secret object from a Docker volume.
 // Returns a Secret object, and an error if any occurs (e.g., if the volume's creation timestamp is not parseable).
 func createSecretFromVolume(volume *volume.Volume) (core.Secret, error) {
-	namespace := volume.Labels[types.NamespaceLabelKey]
+	namespace := volume.Labels[types.NamespaceNameLabelKey]
 
 	secret := core.Secret{
 		TypeMeta: metav1.TypeMeta{

--- a/internal/adapter/types/labels.go
+++ b/internal/adapter/types/labels.go
@@ -1,23 +1,32 @@
 package types
 
+// TODO: instead of using a constant to store the last applied config for each kind of resource
+// see if we can introduce a generic constant such as LastAppliedConfigLabelKey
+
 const (
+	// NamespaceLastAppliedConfigLabelKey is the key used to store the namespace specific last applied configuration in the container labels
+	NamespaceLastAppliedConfigLabelKey = "namespace.k2d.io/last-applied-configuration"
+
+	// NamespaceNameLabelKey is the key used to store the namespace name associated to a Docker resource in its labels
+	NamespaceNameLabelKey = "namespace.k2d.io/name"
+
 	// NetworkNameLabelKey is the key used to store the network name in the container labels
 	NetworkNameLabelKey = "networking.k2d.io/network-name"
 
-	// NamespaceLabelKey is the key used to store the namespace name associated to a Docker resource in its labels
-	NamespaceLabelKey = "namespace.k2d.io/name"
+	// PersistentVolumeClaimLastAppliedConfigLabelKey is the key used to store the service specific last applied configuration in the container labels
+	PersistentVolumeClaimLastAppliedConfigLabelKey = "persistentvolumeclaim.k2d.io/last-applied-configuration"
 
-	// NamespaceLastAppliedConfigLabelKey is the key used to store the namespace specific last applied configuration in the container labels
-	NamespaceLastAppliedConfigLabelKey = "namespace.k2d.io/last-applied-configuration"
+	// PersistentVolumeClaimNameLabelKey is the key used to store the persistent volume name in the container labels
+	PersistentVolumeClaimNameLabelKey = "storage.k2d.io/pvc-name"
+
+	// PersistentVolumeNameLabelKey is the key used to store the persistent volume name in the container labels
+	PersistentVolumeNameLabelKey = "storage.k2d.io/pv-name"
 
 	// PodLastAppliedConfigLabelKey is the key used to store the pod specific last applied configuration in the container labels
 	PodLastAppliedConfigLabelKey = "pod.k2d.io/last-applied-configuration"
 
 	// ServiceLastAppliedConfigLabelKey is the key used to store the service specific last applied configuration in the container labels
 	ServiceLastAppliedConfigLabelKey = "service.k2d.io/last-applied-configuration"
-
-	// PersistentVolumeClaimLastAppliedConfigLabelKey is the key used to store the service specific last applied configuration in the container labels
-	PersistentVolumeClaimLastAppliedConfigLabelKey = "persistentvolumeclaim.k2d.io/last-applied-configuration"
 
 	// ServiceNameLabelKey is the key used to store the service name in the container labels
 	ServiceNameLabelKey = "workload.k2d.io/service-name"
@@ -30,12 +39,6 @@ const (
 
 	// WorkloadNameLabelKey is the key used to store the workload name in the container labels
 	WorkloadNameLabelKey = "workload.k2d.io/name"
-
-	// PersistentVolumeLabelKey is the key used to store the persistent volume name in the container labels
-	PersistentVolumeLabelKey = "storage.k2d.io/pv"
-
-	// PersistentVolumeClaimLabelKey is the key used to store the persistent volume name in the container labels
-	PersistentVolumeClaimLabelKey = "storage.k2d.io/pvc"
 )
 
 const (

--- a/internal/api/apis/storage.k8s.io/storage.go
+++ b/internal/api/apis/storage.k8s.io/storage.go
@@ -41,7 +41,7 @@ func (svc StorageService) ListAPIResources(r *restful.Request, w *restful.Respon
 				SingularName: "",
 				Name:         "storageclasses",
 				ShortNames:   []string{"sc"},
-				Verbs:        []string{"get,list"},
+				Verbs:        []string{"list", "get"},
 				Namespaced:   false,
 			},
 		},
@@ -51,6 +51,6 @@ func (svc StorageService) ListAPIResources(r *restful.Request, w *restful.Respon
 }
 
 func (svc StorageService) RegisterStorageAPI(routes *restful.WebService) {
-	// storage
+	// storageclasses
 	svc.storageclasses.RegisterStorageClassAPI(routes)
 }


### PR DESCRIPTION
This PR follows up on the implementation of the Reclaim policy for persistent volume introduced in #52

It moves all the system configmaps that are used to store information about PVC inside the k2d system namespace instead of storing them in the same namespace where the PVC resides.

Related to #12 