### PR TITLE
refactor: update pvc and pv association logic

### DIFF
--- a/internal/adapter/converter/persistentvolumeclaim.go
+++ b/internal/adapter/converter/persistentvolumeclaim.go
@@ -1,10 +1,6 @@
 package converter
 
 import (
-	"fmt"
-	"time"
-
-	"github.com/portainer/k2d/internal/adapter/naming"
 	k2dtypes "github.com/portainer/k2d/internal/adapter/types"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -12,20 +8,6 @@ import (
 )
 
 func (converter *DockerAPIConverter) UpdateConfigMapToPersistentVolumeClaim(persistentVolumeClaim *core.PersistentVolumeClaim, configMap *corev1.ConfigMap) error {
-	// TODO: this should be reviewed, there should be a single way to retrieve information from the store interface
-	// creation-timestamp can be obtained from a label or directly from the metadata, based on how the K2D_STORE_BACKEND is set
-	creationDate := ""
-	if configMap.Labels["store.k2d.io/filesystem/creation-timestamp"] != "" {
-		creationDate = configMap.Labels["store.k2d.io/filesystem/creation-timestamp"]
-	} else {
-		creationDate = configMap.CreationTimestamp.Format(time.RFC3339)
-	}
-
-	timeConvertedCreationDate, err := time.Parse(time.RFC3339, creationDate)
-	if err != nil {
-		return fmt.Errorf("unable to parse persistent volume claim creation date: %w", err)
-	}
-
 	storageClassName := "local"
 
 	persistentVolumeClaim.TypeMeta = metav1.TypeMeta{
@@ -37,7 +19,7 @@ func (converter *DockerAPIConverter) UpdateConfigMapToPersistentVolumeClaim(pers
 		Name:      configMap.Labels[k2dtypes.PersistentVolumeClaimNameLabelKey],
 		Namespace: configMap.Labels[k2dtypes.NamespaceNameLabelKey],
 		CreationTimestamp: metav1.Time{
-			Time: timeConvertedCreationDate,
+			Time: configMap.CreationTimestamp.Time,
 		},
 		Annotations: map[string]string{
 			"kubectl.kubernetes.io/last-applied-configuration": configMap.Labels[k2dtypes.PersistentVolumeClaimLastAppliedConfigLabelKey],
@@ -46,7 +28,7 @@ func (converter *DockerAPIConverter) UpdateConfigMapToPersistentVolumeClaim(pers
 
 	persistentVolumeClaim.Spec = core.PersistentVolumeClaimSpec{
 		StorageClassName: &storageClassName,
-		VolumeName:       naming.BuildPersistentVolumeName(configMap.Labels[k2dtypes.PersistentVolumeClaimNameLabelKey], configMap.Labels[k2dtypes.NamespaceNameLabelKey]),
+		VolumeName:       configMap.Labels[k2dtypes.PersistentVolumeNameLabelKey],
 		AccessModes: []core.PersistentVolumeAccessMode{
 			core.ReadWriteOnce,
 		},

--- a/internal/adapter/converter/pod.go
+++ b/internal/adapter/converter/pod.go
@@ -241,7 +241,6 @@ func (converter *DockerAPIConverter) setResourceRequirements(hostConfig *contain
 //
 // It returns an error if any occurred fetching the Secret or obtaining the bind mappings fails.
 func (converter *DockerAPIConverter) SetServiceAccountTokenAndCACert(hostConfig *container.HostConfig) error {
-	// TODO: this is also a system resource
 	secret, err := converter.secretStore.GetSecret(k2dtypes.K2dServiceAccountSecretName, k2dtypes.K2DNamespaceName)
 	if err != nil {
 		return fmt.Errorf("unable to get secret %s: %w", k2dtypes.K2dServiceAccountSecretName, err)

--- a/internal/adapter/types/labels.go
+++ b/internal/adapter/types/labels.go
@@ -16,10 +16,10 @@ const (
 	// PersistentVolumeClaimLastAppliedConfigLabelKey is the key used to store the service specific last applied configuration in the container labels
 	PersistentVolumeClaimLastAppliedConfigLabelKey = "persistentvolumeclaim.k2d.io/last-applied-configuration"
 
-	// PersistentVolumeClaimNameLabelKey is the key used to store the persistent volume name in the container labels
+	// PersistentVolumeClaimNameLabelKey is the key used to store the persistent volume claim name in the labels of a system configmap
 	PersistentVolumeClaimNameLabelKey = "storage.k2d.io/pvc-name"
 
-	// PersistentVolumeNameLabelKey is the key used to store the persistent volume name in the container labels
+	// PersistentVolumeNameLabelKey is the key used to store the persistent volume name in the labels of a system configmap or a Docker volume
 	PersistentVolumeNameLabelKey = "storage.k2d.io/pv-name"
 
 	// PodLastAppliedConfigLabelKey is the key used to store the pod specific last applied configuration in the container labels


### PR DESCRIPTION
This PR refactors the PV and PVC association logic to support some Edge use cases such as re-associating a PV to a PVC with a different name.

Follow up of https://github.com/portainer/k2d/pull/57, related to #12 