### PR TITLE
refactor: rename label namespaces

### DIFF
--- a/internal/adapter/container_utils.go
+++ b/internal/adapter/container_utils.go
@@ -225,7 +225,7 @@ func (adapter *KubeDockerAdapter) getContainer(ctx context.Context, containerNam
 //     the function returns an error wrapped with a description of the failed step.
 func (adapter *KubeDockerAdapter) createContainerFromPodSpec(ctx context.Context, options ContainerCreationOptions) error {
 	if options.lastAppliedConfiguration != "" {
-		options.labels[k2dtypes.WorkloadLastAppliedConfigLabelKey] = options.lastAppliedConfiguration
+		options.labels[k2dtypes.LastAppliedConfigLabelKey] = options.lastAppliedConfiguration
 	}
 
 	internalPodSpec := core.PodSpec{}
@@ -255,7 +255,7 @@ func (adapter *KubeDockerAdapter) createContainerFromPodSpec(ctx context.Context
 	}
 
 	if existingContainer != nil {
-		if options.lastAppliedConfiguration == existingContainer.Config.Labels[k2dtypes.WorkloadLastAppliedConfigLabelKey] {
+		if options.lastAppliedConfiguration == existingContainer.Config.Labels[k2dtypes.LastAppliedConfigLabelKey] {
 			adapter.logger.Infof("container with the name %s already exists with the same configuration. The update will be skipped", containerCfg.ContainerName)
 			return nil
 		}

--- a/internal/adapter/converter/deployment.go
+++ b/internal/adapter/converter/deployment.go
@@ -20,7 +20,7 @@ func (converter *DockerAPIConverter) UpdateDeploymentFromContainerInfo(deploymen
 		deployment.ObjectMeta.Annotations = make(map[string]string)
 	}
 
-	deployment.ObjectMeta.Annotations["kubectl.kubernetes.io/last-applied-configuration"] = container.Labels[k2dtypes.WorkloadLastAppliedConfigLabelKey]
+	deployment.ObjectMeta.Annotations["kubectl.kubernetes.io/last-applied-configuration"] = container.Labels[k2dtypes.LastAppliedConfigLabelKey]
 
 	containerState := container.State
 

--- a/internal/adapter/converter/namespace.go
+++ b/internal/adapter/converter/namespace.go
@@ -19,7 +19,7 @@ func (converter *DockerAPIConverter) ConvertNetworkToNamespace(namespaceName str
 			Name:              namespaceName,
 			CreationTimestamp: metav1.NewTime(time.Unix(network.Created.Unix(), 0)),
 			Annotations: map[string]string{
-				"kubectl.kubernetes.io/last-applied-configuration": network.Labels[k2dtypes.NamespaceLastAppliedConfigLabelKey],
+				"kubectl.kubernetes.io/last-applied-configuration": network.Labels[k2dtypes.LastAppliedConfigLabelKey],
 			},
 		},
 		Status: core.NamespaceStatus{

--- a/internal/adapter/converter/persistentvolumeclaim.go
+++ b/internal/adapter/converter/persistentvolumeclaim.go
@@ -22,7 +22,7 @@ func (converter *DockerAPIConverter) UpdateConfigMapToPersistentVolumeClaim(pers
 			Time: configMap.CreationTimestamp.Time,
 		},
 		Annotations: map[string]string{
-			"kubectl.kubernetes.io/last-applied-configuration": configMap.Labels[k2dtypes.PersistentVolumeClaimLastAppliedConfigLabelKey],
+			"kubectl.kubernetes.io/last-applied-configuration": configMap.Labels[k2dtypes.LastAppliedConfigLabelKey],
 		},
 	}
 

--- a/internal/adapter/converter/pod.go
+++ b/internal/adapter/converter/pod.go
@@ -47,7 +47,7 @@ func (converter *DockerAPIConverter) ConvertContainerToPod(container types.Conta
 			CreationTimestamp: metav1.NewTime(time.Unix(container.Created, 0)),
 			Namespace:         container.Labels[k2dtypes.NamespaceNameLabelKey],
 			Annotations: map[string]string{
-				"kubectl.kubernetes.io/last-applied-configuration": container.Labels[k2dtypes.WorkloadLastAppliedConfigLabelKey],
+				"kubectl.kubernetes.io/last-applied-configuration": container.Labels[k2dtypes.LastAppliedConfigLabelKey],
 			},
 		},
 		Spec: core.PodSpec{

--- a/internal/adapter/deployment.go
+++ b/internal/adapter/deployment.go
@@ -41,7 +41,7 @@ func (adapter *KubeDockerAdapter) CreateContainerFromDeployment(ctx context.Cont
 		if err != nil {
 			return fmt.Errorf("unable to marshal deployment: %w", err)
 		}
-		opts.labels[k2dtypes.WorkloadLastAppliedConfigLabelKey] = string(deploymentData)
+		opts.labels[k2dtypes.LastAppliedConfigLabelKey] = string(deploymentData)
 	}
 
 	opts.lastAppliedConfiguration = deployment.ObjectMeta.Annotations["kubectl.kubernetes.io/last-applied-configuration"]
@@ -124,11 +124,11 @@ func (adapter *KubeDockerAdapter) ListDeployments(ctx context.Context, namespace
 }
 
 func (adapter *KubeDockerAdapter) buildDeploymentFromContainer(container types.Container) (*apps.Deployment, error) {
-	if container.Labels[k2dtypes.WorkloadLastAppliedConfigLabelKey] == "" {
-		return nil, fmt.Errorf("unable to build deployment, missing %s label on container %s", k2dtypes.WorkloadLastAppliedConfigLabelKey, container.Names[0])
+	if container.Labels[k2dtypes.LastAppliedConfigLabelKey] == "" {
+		return nil, fmt.Errorf("unable to build deployment, missing %s label on container %s", k2dtypes.LastAppliedConfigLabelKey, container.Names[0])
 	}
 
-	deploymentData := container.Labels[k2dtypes.WorkloadLastAppliedConfigLabelKey]
+	deploymentData := container.Labels[k2dtypes.LastAppliedConfigLabelKey]
 
 	versionedDeployment := appsv1.Deployment{}
 

--- a/internal/adapter/namespace.go
+++ b/internal/adapter/namespace.go
@@ -47,8 +47,8 @@ func (adapter *KubeDockerAdapter) CreateNetworkFromNamespace(ctx context.Context
 	networkOptions := types.NetworkCreate{
 		Driver: "bridge",
 		Labels: map[string]string{
-			k2dtypes.NamespaceNameLabelKey:              namespace.Name,
-			k2dtypes.NamespaceLastAppliedConfigLabelKey: lastAppliedConfiguration,
+			k2dtypes.NamespaceNameLabelKey:     namespace.Name,
+			k2dtypes.LastAppliedConfigLabelKey: lastAppliedConfiguration,
 		},
 		Options: map[string]string{
 			"com.docker.network.bridge.name": networkName,

--- a/internal/adapter/persistentvolumeclaim.go
+++ b/internal/adapter/persistentvolumeclaim.go
@@ -213,10 +213,10 @@ func (adapter *KubeDockerAdapter) listPersistentVolumeClaims(ctx context.Context
 		namespace := configMap.Labels[k2dtypes.NamespaceNameLabelKey]
 
 		if namespaceName == "" || namespace == namespaceName {
-			LastAppliedConfigLabelKey := configMap.Labels[k2dtypes.LastAppliedConfigLabelKey]
+			pvcLastAppliedConfig := configMap.Labels[k2dtypes.LastAppliedConfigLabelKey]
 
-			if LastAppliedConfigLabelKey != "" {
-				persistentVolumeClaim, err := adapter.updatePersistentVolumeClaimFromVolume(LastAppliedConfigLabelKey, &configMap)
+			if pvcLastAppliedConfig != "" {
+				persistentVolumeClaim, err := adapter.updatePersistentVolumeClaimFromVolume(pvcLastAppliedConfig, &configMap)
 				if err != nil {
 					return core.PersistentVolumeClaimList{}, fmt.Errorf("unable to update persistent volume claim from volume: %w", err)
 				}

--- a/internal/adapter/types/labels.go
+++ b/internal/adapter/types/labels.go
@@ -1,41 +1,40 @@
 package types
 
-// TODO: instead of using a constant to store the last applied config for each kind of resource
-// see if we can introduce a generic constant such as LastAppliedConfigLabelKey
-
 const (
-	// NamespaceLastAppliedConfigLabelKey is the key used to store the namespace specific last applied configuration in the container labels
-	NamespaceLastAppliedConfigLabelKey = "namespace.k2d.io/last-applied-configuration"
+	// LastAppliedConfigLabelKey is the key used to store the last applied configuration of a resource in the container labels
+	// It can be used to retrieve the original workload definition (deployment, pod) from a container or the resource definition of resource kinds (namespace, persistent volume claim)
+	LastAppliedConfigLabelKey = "resource.k2d.io/last-applied-configuration"
 
 	// NamespaceNameLabelKey is the key used to store the namespace name associated to a Docker resource in its labels
-	NamespaceNameLabelKey = "namespace.k2d.io/name"
+	NamespaceNameLabelKey = "resource.k2d.io/namespace-name"
 
+	// PodLastAppliedConfigLabelKey is the key used to store the pod definition in the container labels
+	// It can be used to retrieve the pod definition from a container created via a deployment
+	PodLastAppliedConfigLabelKey = "resource.k2d.io/pod/last-applied-configuration"
+
+	// ServiceLastAppliedConfigLabelKey is the key used to store the service definition associated to a workload in the container labels
+	ServiceLastAppliedConfigLabelKey = "resource.k2d.io/service/last-applied-configuration"
+)
+
+const (
 	// NetworkNameLabelKey is the key used to store the network name in the container labels
 	NetworkNameLabelKey = "networking.k2d.io/network-name"
+)
 
-	// PersistentVolumeClaimLastAppliedConfigLabelKey is the key used to store the service specific last applied configuration in the container labels
-	PersistentVolumeClaimLastAppliedConfigLabelKey = "persistentvolumeclaim.k2d.io/last-applied-configuration"
-
+const (
 	// PersistentVolumeClaimNameLabelKey is the key used to store the persistent volume claim name in the labels of a system configmap
 	PersistentVolumeClaimNameLabelKey = "storage.k2d.io/pvc-name"
 
 	// PersistentVolumeNameLabelKey is the key used to store the persistent volume name in the labels of a system configmap or a Docker volume
 	PersistentVolumeNameLabelKey = "storage.k2d.io/pv-name"
+)
 
-	// PodLastAppliedConfigLabelKey is the key used to store the pod specific last applied configuration in the container labels
-	PodLastAppliedConfigLabelKey = "pod.k2d.io/last-applied-configuration"
-
-	// ServiceLastAppliedConfigLabelKey is the key used to store the service specific last applied configuration in the container labels
-	ServiceLastAppliedConfigLabelKey = "service.k2d.io/last-applied-configuration"
-
-	// ServiceNameLabelKey is the key used to store the service name in the container labels
+const (
+	// ServiceNameLabelKey is the key used to store the service name associated to the workload in the container labels
 	ServiceNameLabelKey = "workload.k2d.io/service-name"
 
 	// WorkloadLabelKey is the key used to store the workload type in the container labels
 	WorkloadLabelKey = "workload.k2d.io/type"
-
-	// WorkloadLastAppliedConfigLabelKey is the key used to store the last applied configuration in the container labels
-	WorkloadLastAppliedConfigLabelKey = "workload.k2d.io/last-applied-configuration"
 
 	// WorkloadNameLabelKey is the key used to store the workload name in the container labels
 	WorkloadNameLabelKey = "workload.k2d.io/name"


### PR DESCRIPTION
This PR changes the label namespaces used to store metadata required by k2d to work properly. The goal is to define namespaces that will allow to store more metadata for future evolutions.

* resource.k2d.io/ namespace is introduced to store generic information across all resources
* networking.k2d.io/ is kept and used for networking purposes
* storage.k2d.io/ is kept and used for storage purposes
* workload.k2d.io/ is kept and used for anything related to workloads