### PR TITLE
fix: review label usage for pvc and volume association

### DIFF
--- a/internal/adapter/converter/persistentvolume.go
+++ b/internal/adapter/converter/persistentvolume.go
@@ -24,7 +24,7 @@ func (converter *DockerAPIConverter) ConvertVolumeToPersistentVolume(volume *vol
 		phase = core.VolumeBound
 		persistentVolumeClaimReference = &core.ObjectReference{
 			Kind:      "PersistentVolumeClaim",
-			Namespace: pvcConfigMap.Labels[k2dtypes.NamespaceNameLabelKey],
+			Namespace: pvcConfigMap.Labels[k2dtypes.PersistentVolumeClaimTargetNamespaceLabelKey],
 			Name:      pvcConfigMap.Labels[k2dtypes.PersistentVolumeClaimNameLabelKey],
 		}
 	}

--- a/internal/adapter/converter/persistentvolumeclaim.go
+++ b/internal/adapter/converter/persistentvolumeclaim.go
@@ -17,7 +17,7 @@ func (converter *DockerAPIConverter) UpdateConfigMapToPersistentVolumeClaim(pers
 
 	persistentVolumeClaim.ObjectMeta = metav1.ObjectMeta{
 		Name:      configMap.Labels[k2dtypes.PersistentVolumeClaimNameLabelKey],
-		Namespace: configMap.Labels[k2dtypes.NamespaceNameLabelKey],
+		Namespace: configMap.Labels[k2dtypes.PersistentVolumeClaimTargetNamespaceLabelKey],
 		CreationTimestamp: metav1.Time{
 			Time: configMap.CreationTimestamp.Time,
 		},

--- a/internal/adapter/deployment.go
+++ b/internal/adapter/deployment.go
@@ -24,7 +24,7 @@ func (adapter *KubeDockerAdapter) CreateContainerFromDeployment(ctx context.Cont
 		labels:        deployment.Spec.Template.Labels,
 	}
 
-	opts.labels[k2dtypes.WorkloadLabelKey] = k2dtypes.DeploymentWorkloadType
+	opts.labels[k2dtypes.WorkloadTypeLabelKey] = k2dtypes.DeploymentWorkloadType
 
 	if deployment.Labels["app.kubernetes.io/managed-by"] == "Helm" {
 		deploymentData, err := json.Marshal(deployment)

--- a/internal/adapter/filters/filters.go
+++ b/internal/adapter/filters/filters.go
@@ -22,7 +22,7 @@ import (
 //	// Now 'filter' can be used in Docker API calls to filter Deployment resources in the 'default' Kubernetes namespace.
 func AllDeployments(namespace string) filters.Args {
 	filter := ByNamespace(namespace)
-	filter.Add("label", fmt.Sprintf("%s=%s", types.WorkloadLabelKey, types.DeploymentWorkloadType))
+	filter.Add("label", fmt.Sprintf("%s=%s", types.WorkloadTypeLabelKey, types.DeploymentWorkloadType))
 	return filter
 }
 
@@ -141,19 +141,19 @@ func ByService(namespace, serviceName string) filters.Args {
 	return filter
 }
 
-// AllPersistentVolumes creates a Docker filter argument that targets resources labeled with a Kubernetes persistent volume name.
-// This function uses the types.PersistentVolumeNameLabelKey constant as the base label key to filter Docker resources.
+// AllPersistentVolumes creates a Docker filter argument that targets resources labeled with a specific type of storage, in this case, Kubernetes persistent volumes.
+// This function uses the types.StorageTypeLabelKey and types.PersistentVolumeStorageType constants to filter Docker resources.
 //
 // Parameters:
 //   - None
 //
 // Returns:
-// - filters.Args: A Docker filter object that can be used to filter Docker API calls based on the presence of the persistent volume name label.
+//   - filters.Args: A Docker filter object that can be used to filter Docker API calls based on the presence of a label indicating the storage type as a Kubernetes persistent volume.
 //
 // Usage Example:
 //
 //	filter := AllPersistentVolumes()
-//	// Now 'filter' can be used in Docker API calls to filter resources that are labeled with any Kubernetes persistent volume name.
+//	// Now 'filter' can be used in Docker API calls to filter resources that are labeled with a specific type of storage as a Kubernetes persistent volume.
 func AllPersistentVolumes() filters.Args {
-	return filters.NewArgs(filters.Arg("label", types.PersistentVolumeNameLabelKey))
+	return filters.NewArgs(filters.Arg("label", fmt.Sprintf("%s=%s", types.StorageTypeLabelKey, types.PersistentVolumeStorageType)))
 }

--- a/internal/adapter/filters/filters.go
+++ b/internal/adapter/filters/filters.go
@@ -8,7 +8,7 @@ import (
 )
 
 // AllDeployments creates a Docker filter argument for Kubernetes Deployments within a given namespace.
-// The function filters Docker resources based on the Workload and Namespace labels, specifically for Deployments.
+// The function filters Docker resources based on the workload type and namespace labels, specifically for Deployments.
 //
 // Parameters:
 //   - namespace: The Kubernetes namespace to filter by.

--- a/internal/adapter/persistentvolume.go
+++ b/internal/adapter/persistentvolume.go
@@ -40,7 +40,7 @@ func (adapter *KubeDockerAdapter) GetPersistentVolume(ctx context.Context, persi
 
 	var boundPVCConfigMap *corev1.ConfigMap
 	for _, configMap := range configMaps.Items {
-		if configMap.Data[k2dtypes.PersistentVolumeNameLabelKey] == volume.Name {
+		if configMap.Labels[k2dtypes.PersistentVolumeNameLabelKey] == volume.Name {
 			boundPVCConfigMap = &configMap
 			break
 		}

--- a/internal/adapter/store/filesystem/configmap.go
+++ b/internal/adapter/store/filesystem/configmap.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/portainer/k2d/internal/adapter/errors"
+	"github.com/portainer/k2d/internal/adapter/types"
 	"github.com/portainer/k2d/pkg/filesystem"
 	"github.com/portainer/k2d/pkg/maputils"
 	corev1 "k8s.io/api/core/v1"
@@ -207,8 +208,8 @@ func (s *FileSystemStore) StoreConfigMap(configMap *corev1.ConfigMap) error {
 	defer s.mutex.Unlock()
 
 	labels := map[string]string{
-		NamespaceNameLabelKey:     configMap.Namespace,
-		CreationTimestampLabelKey: time.Now().UTC().Format(time.RFC3339),
+		types.NamespaceNameLabelKey: configMap.Namespace,
+		CreationTimestampLabelKey:   time.Now().UTC().Format(time.RFC3339),
 	}
 	maputils.MergeMapsInPlace(labels, configMap.Labels)
 
@@ -296,7 +297,7 @@ func (s *FileSystemStore) loadMetadataAndInitConfigMaps(metadataFiles []string, 
 			return configMaps, fmt.Errorf("unable to load configmap metadata from disk: %w", err)
 		}
 
-		namespaceName := metadata[NamespaceNameLabelKey]
+		namespaceName := metadata[types.NamespaceNameLabelKey]
 		if namespace != "" && namespace != namespaceName {
 			continue
 		}

--- a/internal/adapter/store/filesystem/secret.go
+++ b/internal/adapter/store/filesystem/secret.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/portainer/k2d/internal/adapter/errors"
+	"github.com/portainer/k2d/internal/adapter/types"
 	"github.com/portainer/k2d/pkg/filesystem"
 	"github.com/portainer/k2d/pkg/maputils"
 	corev1 "k8s.io/api/core/v1"
@@ -213,8 +214,8 @@ func (s *FileSystemStore) StoreSecret(secret *corev1.Secret) error {
 	defer s.mutex.Unlock()
 
 	labels := map[string]string{
-		NamespaceNameLabelKey:     secret.Namespace,
-		CreationTimestampLabelKey: time.Now().UTC().Format(time.RFC3339),
+		types.NamespaceNameLabelKey: secret.Namespace,
+		CreationTimestampLabelKey:   time.Now().UTC().Format(time.RFC3339),
 	}
 	maputils.MergeMapsInPlace(labels, secret.Labels)
 
@@ -316,7 +317,7 @@ func (s *FileSystemStore) loadMetadataAndInitSecrets(metadataFiles []string, nam
 			continue
 		}
 
-		namespaceName := metadata[NamespaceNameLabelKey]
+		namespaceName := metadata[types.NamespaceNameLabelKey]
 		if namespace != "" && namespace != namespaceName {
 			continue
 		}

--- a/internal/adapter/store/filesystem/store.go
+++ b/internal/adapter/store/filesystem/store.go
@@ -24,11 +24,6 @@ const (
 )
 
 const (
-	// NamespaceNameLabelKey is the key used to store the namespace of a Configmap or Secret resource
-	// in the associated metadata file
-	// It is used to identify the namespace associated with a ConfigMap or a Secret
-	NamespaceNameLabelKey = "store.k2d.io/filesystem/namespace-name"
-
 	// CreationTimestampLabelKey is the key used to store the creation timestamp of a Configmap or Secret resource
 	// in the associated metadata file
 	CreationTimestampLabelKey = "store.k2d.io/filesystem/creation-timestamp"

--- a/internal/adapter/types/labels.go
+++ b/internal/adapter/types/labels.go
@@ -27,14 +27,28 @@ const (
 
 	// PersistentVolumeNameLabelKey is the key used to store the persistent volume name in the labels of a system configmap or a Docker volume
 	PersistentVolumeNameLabelKey = "storage.k2d.io/pv-name"
+
+	// PersistentVolumeClaimTargetNamespaceLabelKey is the key used to store the target namespace of a persistent volume claim in the labels of a system configmap
+	// This is used to identify the namespace where the persistent volume claim is used (e.g. the namespace of the workload)
+	PersistentVolumeClaimTargetNamespaceLabelKey = "storage.k2d.io/pvc-target-namespace"
+
+	// StorageTypeLabelKey is the key used to store the storage type in the labels of a system configmap or a Docker volume
+	// It is used to differentiate between persistent volumes and config maps when listing volumes
+	StorageTypeLabelKey = "storage.k2d.io/type"
+)
+
+const (
+	// PersistentVolumeStorageType is the label value used to identify a persistent volume storage
+	// It is stored inside metadata as a label and used to filter persistent volumes when listing persistent volumes
+	PersistentVolumeStorageType = "pv"
 )
 
 const (
 	// ServiceNameLabelKey is the key used to store the service name associated to the workload in the container labels
 	ServiceNameLabelKey = "workload.k2d.io/service-name"
 
-	// WorkloadLabelKey is the key used to store the workload type in the container labels
-	WorkloadLabelKey = "workload.k2d.io/type"
+	// WorkloadTypeLabelKey is the key used to store the workload type in the container labels
+	WorkloadTypeLabelKey = "workload.k2d.io/type"
 
 	// WorkloadNameLabelKey is the key used to store the workload name in the container labels
 	WorkloadNameLabelKey = "workload.k2d.io/name"


### PR DESCRIPTION
This PR introduces a new label to identify volumes that are used as persistent volumes. This is to differentiates them from configmap and secret volumes when using the volume backend store, specifically system configmaps that are tied to a PVC.

It also make sure that the use of labels is similar across both backend store implementations.

Replaces https://github.com/portainer/k2d/pull/66
Related to #28 