### PR TITLE
fix: remove ulimit when re-creating container

### DIFF
--- a/internal/adapter/container_utils.go
+++ b/internal/adapter/container_utils.go
@@ -130,7 +130,7 @@ func (adapter *KubeDockerAdapter) buildContainerConfigurationFromExistingContain
 		return converter.ContainerConfiguration{}, fmt.Errorf("unable to inspect container: %w", err)
 	}
 
-	return converter.ContainerConfiguration{
+	containerConfiguration := converter.ContainerConfiguration{
 		ContainerName: containerDetails.Name,
 		ContainerConfig: &container.Config{
 			Image:        containerDetails.Image,
@@ -150,7 +150,11 @@ func (adapter *KubeDockerAdapter) buildContainerConfigurationFromExistingContain
 		NetworkConfig: &network.NetworkingConfig{
 			EndpointsConfig: containerDetails.NetworkSettings.Networks,
 		},
-	}, nil
+	}
+
+	containerConfiguration.HostConfig.Resources.Ulimits = nil
+
+	return containerConfiguration, nil
 }
 
 // ContainerCreationOptions serves as a parameter object for container creation operations.

--- a/internal/adapter/container_utils.go
+++ b/internal/adapter/container_utils.go
@@ -133,7 +133,7 @@ func (adapter *KubeDockerAdapter) buildContainerConfigurationFromExistingContain
 	adapter.logger.Debugf("container details: %+v", containerDetails)
 
 	containerConfiguration := converter.ContainerConfiguration{
-		ContainerName: containerDetails.Name,
+		ContainerName: strings.TrimPrefix(containerDetails.Name, "/"),
 		ContainerConfig: &container.Config{
 			Image:        containerDetails.Image,
 			Labels:       containerDetails.Config.Labels,

--- a/internal/adapter/container_utils.go
+++ b/internal/adapter/container_utils.go
@@ -130,6 +130,8 @@ func (adapter *KubeDockerAdapter) buildContainerConfigurationFromExistingContain
 		return converter.ContainerConfiguration{}, fmt.Errorf("unable to inspect container: %w", err)
 	}
 
+	adapter.logger.Debugf("container details: %+v", containerDetails)
+
 	containerConfiguration := converter.ContainerConfiguration{
 		ContainerName: containerDetails.Name,
 		ContainerConfig: &container.Config{
@@ -151,6 +153,8 @@ func (adapter *KubeDockerAdapter) buildContainerConfigurationFromExistingContain
 			EndpointsConfig: containerDetails.NetworkSettings.Networks,
 		},
 	}
+
+	adapter.logger.Debugf("container configuration: %+v", containerConfiguration)
 
 	// We set the ulimits to nil because Podman is not able to create the container when inheriting the ulimits
 	// from the previous container configuration.

--- a/internal/adapter/container_utils.go
+++ b/internal/adapter/container_utils.go
@@ -152,6 +152,8 @@ func (adapter *KubeDockerAdapter) buildContainerConfigurationFromExistingContain
 		},
 	}
 
+	// We set the ulimits to nil because Podman is not able to create the container when inheriting the ulimits
+	// from the previous container configuration.
 	containerConfiguration.HostConfig.Resources.Ulimits = nil
 
 	return containerConfiguration, nil


### PR DESCRIPTION
This PR sets the ulimit associated to a container to null when re-creating a container instead of inheriting it from the previous container configuration.

This should solve the issue that happens when running k2d under Podman and creating services (that re-creates container under the hood).

As setting ulimits is not supported by Kubernetes natively this should not be a breaking change.