### PR TITLE
feat: update k2d version format

### DIFF
--- a/internal/api/root/version/version.go
+++ b/internal/api/root/version/version.go
@@ -17,7 +17,7 @@ func (svc VersionService) Version(r *restful.Request, w *restful.Response) {
 	version := version.Info{
 		Major:      "1",
 		Minor:      "28",
-		GitVersion: "v1.28.2-k2d",
+		GitVersion: "v1.28.2+k2d.100b",
 		GoVersion:  runtime.Version(),
 		Compiler:   "gc",
 		Platform:   "linux/amd64",


### PR DESCRIPTION
This PR updates the format of the version returned by the API server to match a more standard format used by other Kubernetes providers (rke, k3s...).

It changes the format from `v1.28.2-k2d` to `v1.28.2+k2d.100b`.